### PR TITLE
ci(cli): 👷‍♀️ Add GitHub Actions build and test workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -1,0 +1,58 @@
+name: "@coat/cli"
+on: push
+
+jobs:
+  build:
+    name: Lint, Test & Build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx --no-install lerna bootstrap
+      - name: Lint
+        run: npm run lint
+        working-directory: ./packages/cli
+      - name: Test
+        run: npm test
+        working-directory: ./packages/cli
+      - name: Build
+        # The pack command does currently not allow to specify an output filename,
+        # however, it does print out the name of the file as the last line.
+        #
+        # In order to always generate the same "coat-cli.tgz" file,
+        # the output file is renamed after npm pack finishes.
+        #
+        # The transpilation and type definition generation are run
+        # automatically with the "prepack" script
+        run: mv "$(npm pack | tail -n 1)" coat-cli.tgz
+        working-directory: ./packages/cli
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coat-cli
+          path: packages/cli/coat-cli.tgz
+  integration-tests:
+    name: Integration tests
+    strategy:
+      matrix:
+        # Integration tests are currently not working on Windows
+        # because individual tests take way too long.
+        #
+        # I want to enable them once I can work out how to resolve
+        # these issues.
+        os: [ubuntu-latest, macos-latest]
+        node: [10, 12, 14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx --no-install lerna bootstrap
+      - name: Run all tests
+        run: npm run test:all
+        working-directory: ./packages/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,16 +49,16 @@
   "license": "MIT",
   "scripts": {
     "build": "run-p build:*",
-    "build:babel": "babel src -d build --extensions '.ts,.ts' --ignore '**/*.d.ts,**/*.test.ts'",
+    "build:babel": "babel src -d build --extensions \".ts,.ts\" --ignore \"**/*.d.ts,**/*.test.ts\"",
     "build:typedefs": "tsc -p tsconfig.build.json",
     "lint": "run-p lint:*",
-    "lint:eslint": "eslint '{src,test}/**/*{.ts,.js}' --max-warnings 0",
+    "lint:eslint": "eslint \"{src,test}/**/*{.ts,.js}\" --max-warnings 0",
     "lint:prettier": "prettier --check src test",
     "lint:tsc": "tsc",
     "prebuild": "rm -rf build",
     "prepack": "npm run build",
-    "test": "cross-env JEST_PROJECT='Unit tests' jest",
-    "test:integration": "cross-env JEST_PROJECT='Integration tests' jest --coverage=false",
+    "test": "cross-env JEST_PROJECT=\"Unit tests\" jest",
+    "test:integration": "cross-env JEST_PROJECT=\"Integration tests\" jest --coverage=false",
     "test:all": "jest"
   }
 }


### PR DESCRIPTION
Adds a workflow to lint, build and test the cli package.

The Lint, Test & Build job verifies that there are no linting issues, runs all unit tests and packs the cli package and uploads it as a build artifact.
Integration tests are run on both linux and mac, each with the Node.js LTS versions 10 and 12, as well as the current version 14.

Windows integration tests are currently not working correctly, since the tests time out as soon as they involve installing a template from a remote location. I plan on adding Windows integration tests as soon as possible and will try to locally get the tests running on a Windows machine.

Resolves #10