### PR TITLE
CI: Decrease npm retry factor for macOS integration tests

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -48,6 +48,13 @@ jobs:
         run: |
           npm ci
           npx --no-install lerna bootstrap
+      - name: Decrease npm retry factors on macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          echo "::set-env name=npm_config_fetch_retries::50"
+          echo "::set-env name=npm_config_fetch_retry_factor::2"
+          echo "::set-env name=npm_config_fetch_retry_mintimeout::50"
+          echo "::set-env name=npm_config_fetch_retry_maxtimeout::6000"
       - name: Run all tests
         run: npm run test:all -- --ci --no-cache --runInBand
         working-directory: ./packages/cli

--- a/packages/cli/test/sync/general.test.ts
+++ b/packages/cli/test/sync/general.test.ts
@@ -6,6 +6,8 @@ import { CoatManifestFileType } from "../../src/types/coat-manifest-file";
 import { PACKAGE_JSON_FILENAME } from "../../src/constants";
 import { cleanupTmpDirs } from "../utils/get-tmp-dir";
 
+jest.setTimeout(120000);
+
 afterAll(() => {
   cleanupTmpDirs();
 });


### PR DESCRIPTION
macOS integration tests are still flaky, a reduction in the npm retry factor appears to help to get npm to retry network requests more frequently.

It still appears that the GitHub Actions mac environment is very inconsistent when it comes to network performance. I'm not sure whether this solves the issue permanently.