### PR TITLE
feat(cli): ✨ Enhance coat run command

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -19,6 +19,7 @@ jobs:
           --ci \
           --no-cache \
           --runInBand \
+          --verbose \
           --coverageReporters json \
           --coverageReporters lcov \
           --coverageReporters text \
@@ -55,5 +56,5 @@ jobs:
           echo "::set-env name=npm_config_fetch_retry_mintimeout::50"
           echo "::set-env name=npm_config_fetch_retry_maxtimeout::6000"
       - name: Run all tests
-        run: npm run test:all -- --ci --no-cache --runInBand
+        run: npm run test:all -- --ci --no-cache --runInBand --verbose
         working-directory: ./packages/cli

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -31,7 +31,6 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ["src/**/*.ts", "!src/**/*.test.ts"],
   coverageReporters: ["text"],
-  verbose: true,
 
   // Workaround to test integration tests
   // with VSCode test explorer jest test adapter:

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -376,6 +376,28 @@
 				"@babel/helper-validator-identifier": "^7.10.4",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/node": {
@@ -2763,14 +2785,16 @@
 			}
 		},
 		"ansi-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -3246,7 +3270,8 @@
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30001129",
@@ -3270,21 +3295,47 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
 			},
 			"dependencies": {
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
-						"has-flag": "^3.0.0"
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -3372,10 +3423,28 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
 			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+			"dev": true,
 			"requires": {
 				"string-width": "^3.1.0",
 				"strip-ansi": "^5.2.0",
 				"wrap-ansi": "^5.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
 			}
 		},
 		"clone": {
@@ -3409,6 +3478,7 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -3416,7 +3486,8 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -3466,6 +3537,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-5.3.0.tgz",
 			"integrity": "sha512-8MhqOB6PWlBfA2vJ8a0bSFKATOdWlHiQlk11IfmQBPaHVP8oP2gsh2MObE6UR3hqDHqvaIvLTyceNW6obVuFHQ==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
 				"date-fns": "^2.0.1",
@@ -3476,6 +3548,30 @@
 				"supports-color": "^6.1.0",
 				"tree-kill": "^1.2.2",
 				"yargs": "^13.3.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				}
 			}
 		},
 		"convert-source-map": {
@@ -3588,7 +3684,8 @@
 		"date-fns": {
 			"version": "2.16.1",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
-			"integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+			"integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==",
+			"dev": true
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -3602,7 +3699,8 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"decimal.js": {
 			"version": "10.2.0",
@@ -3773,7 +3871,8 @@
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -3796,6 +3895,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -4626,6 +4726,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
@@ -4740,7 +4841,8 @@
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
 		},
 		"get-package-type": {
 			"version": "0.1.0",
@@ -4881,7 +4983,8 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.1",
@@ -4933,7 +5036,8 @@
 		"hosted-git-info": {
 			"version": "2.8.8",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
@@ -5234,7 +5338,8 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -5334,7 +5439,8 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-generator-fn": {
 			"version": "2.1.0",
@@ -8398,7 +8504,8 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -8520,6 +8627,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
 			"requires": {
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
@@ -8654,6 +8762,41 @@
 			"dev": true,
 			"requires": {
 				"fs-monkey": "1.0.1"
+			}
+		},
+		"memory-streams": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
+			"integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "~1.0.2"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
 			}
 		},
 		"merge-stream": {
@@ -8856,6 +8999,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
 			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"resolve": "^1.10.0",
@@ -8866,7 +9010,8 @@
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
 				}
 			}
 		},
@@ -9126,6 +9271,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -9134,6 +9280,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
 			"requires": {
 				"p-limit": "^2.0.0"
 			}
@@ -9141,7 +9288,8 @@
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true
 		},
 		"parent-module": {
 			"version": "1.0.1",
@@ -9156,6 +9304,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
 			"requires": {
 				"error-ex": "^1.3.1",
 				"json-parse-better-errors": "^1.0.1"
@@ -9189,7 +9338,8 @@
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -9205,7 +9355,8 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-type": {
 			"version": "4.0.0",
@@ -9228,7 +9379,8 @@
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"dev": true
 		},
 		"pirates": {
 			"version": "4.0.1",
@@ -9369,6 +9521,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
 			"integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+			"dev": true,
 			"requires": {
 				"normalize-package-data": "^2.3.2",
 				"parse-json": "^4.0.0",
@@ -9669,17 +9822,20 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
 			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -9903,7 +10059,8 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -10137,12 +10294,14 @@
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A="
+			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
 			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -10151,12 +10310,14 @@
 		"spdx-exceptions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -10165,7 +10326,8 @@
 		"spdx-license-ids": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"dev": true
 		},
 		"split-string": {
 			"version": "3.1.0",
@@ -10273,10 +10435,28 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+			"dev": true,
 			"requires": {
 				"emoji-regex": "^7.0.1",
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^5.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
 			}
 		},
 		"string.prototype.trimend": {
@@ -10309,11 +10489,12 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"dev": true,
 			"requires": {
-				"ansi-regex": "^4.1.0"
+				"ansi-regex": "^5.0.0"
 			}
 		},
 		"strip-bom": {
@@ -10343,6 +10524,7 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
 			"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -10527,7 +10709,8 @@
 		"tree-kill": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true
 		},
 		"tslib": {
 			"version": "1.13.0",
@@ -10763,6 +10946,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -10865,7 +11049,8 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
 		},
 		"word-wrap": {
 			"version": "1.2.3",
@@ -10877,10 +11062,28 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
 			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
 				"string-width": "^3.0.0",
 				"strip-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
 			}
 		},
 		"wrappy": {
@@ -10930,12 +11133,14 @@
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
 		},
 		"yargs": {
 			"version": "13.3.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
 			"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+			"dev": true,
 			"requires": {
 				"cliui": "^5.0.0",
 				"find-up": "^3.0.0",
@@ -10953,6 +11158,7 @@
 			"version": "13.1.2",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
 			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,8 +6,8 @@
     "coat": "./bin/coat.js"
   },
   "dependencies": {
+    "chalk": "4.1.0",
     "commander": "6.1.0",
-    "concurrently": "5.3.0",
     "execa": "4.0.3",
     "fs-extra": "9.0.1",
     "immer": "7.0.9",
@@ -43,6 +43,7 @@
     "@types/validate-npm-package-name": "3.0.0",
     "@typescript-eslint/eslint-plugin": "4.1.1",
     "@typescript-eslint/parser": "4.1.1",
+    "concurrently": "5.3.0",
     "cross-env": "7.0.2",
     "eslint": "7.9.0",
     "eslint-config-prettier": "6.11.0",
@@ -50,6 +51,8 @@
     "jest": "26.4.2",
     "jest-circus": "26.4.2",
     "memfs": "3.2.0",
+    "memory-streams": "0.1.3",
+    "strip-ansi": "6.0.0",
     "tmp": "0.2.1",
     "typescript": "4.0.2"
   },

--- a/packages/cli/src/run/index.test.ts
+++ b/packages/cli/src/run/index.test.ts
@@ -1,31 +1,135 @@
-import concurrently from "concurrently";
+import fs from "fs-extra";
+import path from "path";
+import { vol } from "memfs";
 import { run } from ".";
+import { PACKAGE_JSON_FILENAME } from "../constants";
+import { runMultipleScripts } from "./run-multiple-scripts";
+import { runSingleScript } from "./run-single-script";
 
-jest.mock("concurrently");
+jest.mock("fs").mock("./run-single-script").mock("./run-multiple-scripts");
 
-const concurrentlyMock = concurrently as jest.Mock;
+const platformRoot = path.parse(process.cwd()).root;
+const testCwd = path.join(platformRoot, "test");
 
 describe("run", () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  test("should prefix provided script patterns with npm:", async () => {
-    const scripts = ["one", "two", "three:*"];
-    await run(scripts);
-    expect(concurrentlyMock).toHaveBeenCalledTimes(1);
-    expect(concurrentlyMock.mock.calls[0][0]).toEqual(
-      scripts.map((script) => `npm:${script}`)
+  beforeEach(async () => {
+    // Place package.json file in
+    // testCwd to be able to access scripts
+    // for testing
+    await fs.outputFile(
+      path.join(testCwd, PACKAGE_JSON_FILENAME),
+      JSON.stringify({
+        scripts: {
+          singleScript: "single script",
+          "multi:1": "multi one",
+          "multi:2": "multi two",
+          "multi:3": "multi three",
+        },
+      })
     );
   });
 
-  test("should call concurrently with kill options for failure", async () => {
-    const scripts = ["one"];
-    await run(scripts);
-
-    expect(concurrentlyMock).toHaveBeenCalledTimes(1);
-    expect(concurrentlyMock.mock.calls[0][1]).toEqual({
-      killOthers: ["failure"],
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
+    vol.reset();
   });
+
+  test("should split script patterns and arguments correctly", async () => {
+    await run(testCwd, ["singleScript", "--arg1", "--arg2", "arg2value"]);
+
+    expect(runSingleScript).toBeCalledTimes(1);
+    expect(runSingleScript).toHaveBeenLastCalledWith(testCwd, "singleScript", [
+      "--arg1",
+      "--arg2",
+      "arg2value",
+    ]);
+  });
+
+  test("should resolve scripts correctly from patterns", async () => {
+    await run(testCwd, ["singleScript*", "multi*"]);
+
+    expect(runMultipleScripts).toHaveBeenCalledTimes(1);
+    expect(runMultipleScripts).toHaveBeenLastCalledWith(
+      testCwd,
+      ["singleScript", "multi:1", "multi:2", "multi:3"],
+      []
+    );
+  });
+
+  test("should throw if no package.json can be found in cwd", async () => {
+    await fs.unlink(path.join(testCwd, PACKAGE_JSON_FILENAME));
+
+    await expect(() =>
+      run(testCwd, ["multi:*", "singleScript"])
+    ).rejects.toHaveProperty(
+      "message",
+      expect.stringMatching(
+        /ENOENT: no such file or directory, open .*package.json/
+      )
+    );
+  });
+
+  test("should throw if no script pattern is provided but only arguments", async () => {
+    await expect(() =>
+      run(testCwd, ["--arg1", "--arg2", "arg2Value"])
+    ).rejects.toHaveProperty("message", "No script pattern provided.");
+  });
+
+  test("should throw if no script can be found for a pattern", async () => {
+    await expect(() =>
+      run(testCwd, ["unknown-pattern:*", "singleScript"])
+    ).rejects.toHaveProperty(
+      "message",
+      "No scripts found in package.json for pattern: unknown-pattern:*"
+    );
+  });
+
+  test("should throw if no script can be found for a script name", async () => {
+    // Place empty package.json without scripts entry to
+    // let run function not find any scripts
+    await fs.outputFile(
+      path.join(testCwd, PACKAGE_JSON_FILENAME),
+      JSON.stringify({})
+    );
+
+    await expect(() => run(testCwd, ["singleScript"])).rejects.toHaveProperty(
+      "message",
+      'No script named "singleScript" found in package.json'
+    );
+  });
+
+  test.each`
+    input                                                 | runParams                                              | explanation
+    ${["singleScript"]}                                   | ${["singleScript", []]}                                | ${"name without arguments"}
+    ${["singleScript", "--arg1", "--arg2", "arg2Value"]}  | ${["singleScript", ["--arg1", "--arg2", "arg2Value"]]} | ${"name with arguments"}
+    ${["singleScript*"]}                                  | ${["singleScript", []]}                                | ${"pattern without arguments"}
+    ${["singleScript*", "--arg1", "--arg2", "arg2Value"]} | ${["singleScript", ["--arg1", "--arg2", "arg2Value"]]} | ${"pattern with arguments"}
+  `(
+    "should run single script from $explanation",
+    async ({ input, runParams }) => {
+      await run(testCwd, input);
+
+      expect(runSingleScript).toHaveBeenCalledTimes(1);
+      expect(runSingleScript).toHaveBeenLastCalledWith(testCwd, ...runParams);
+    }
+  );
+
+  test.each`
+    input                                                           | runParams                                                                 | explanation
+    ${["multi:1", "singleScript"]}                                  | ${[["multi:1", "singleScript"], []]}                                      | ${"two single scripts without arguments"}
+    ${["multi:1", "singleScript", "--arg1", "--arg2", "arg2Value"]} | ${[["multi:1", "singleScript"], ["--arg1", "--arg2", "arg2Value"]]}       | ${"two single scripts with arguments"}
+    ${["multi:*"]}                                                  | ${[["multi:1", "multi:2", "multi:3"], []]}                                | ${"pattern without arguments"}
+    ${["multi:*", "--arg1", "--arg2", "arg2Value"]}                 | ${[["multi:1", "multi:2", "multi:3"], ["--arg1", "--arg2", "arg2Value"]]} | ${"pattern with arguments"}
+  `(
+    "should run single script from $explanation",
+    async ({ input, runParams }) => {
+      await run(testCwd, input);
+
+      expect(runMultipleScripts).toHaveBeenCalledTimes(1);
+      expect(runMultipleScripts).toHaveBeenLastCalledWith(
+        testCwd,
+        ...runParams
+      );
+    }
+  );
 });

--- a/packages/cli/src/run/index.ts
+++ b/packages/cli/src/run/index.ts
@@ -1,8 +1,13 @@
-import concurrently from "concurrently";
+import { promises as fs } from "fs";
+import path from "path";
+import { PACKAGE_JSON_FILENAME } from "../constants";
+import { PackageJson } from "type-fest";
+import { runSingleScript } from "./run-single-script";
+import { runMultipleScripts } from "./run-multiple-scripts";
 
 /**
  * Runs the provided script patterns in parallel
- * from the current process working directory.
+ * from the specified working directory.
  *
  * Script patterns refer to script names in the working directory's
  * package.json file.
@@ -18,22 +23,104 @@ import concurrently from "concurrently";
  * Using "build:*" as a script pattern will run both the
  * build:tsc and build:babel scripts in parallel.
  *
- * TODO: See #40
- * Allow specifying the cwd when calling run
- *
+ * @param cwd The working directory of the current project
  * @param scriptPatterns The script patterns that will be evaluated and run
  */
-export async function run(scriptPatterns: string[]): Promise<void> {
-  // Prefix script patterns with npm: to let concurrently
-  // know that it should run scripts from package.json
-  const npmScriptPatterns = scriptPatterns.map((pattern) => `npm:${pattern}`);
+export async function run(
+  cwd: string,
+  scriptPatterns: string[]
+): Promise<void> {
+  // Split patterns by script names and arguments that
+  // will be forwarded to each script.
+  //
+  // All patterns that follow the first dash ("-")
+  // will be forwarded as arguments.
+  //
+  // Example:
+  // scriptPatterns: ["build:* test --watch files"]
+  // scriptInputs: ["build:*", "test"]
+  // args: ["--watch", "files"]
+  const { scriptInputs, args } = scriptPatterns.reduce<{
+    scriptInputs: string[];
+    args: string[];
+  }>(
+    (accumulator, pattern) => {
+      if (accumulator.args.length || pattern.startsWith("-")) {
+        accumulator.args.push(pattern);
+      } else {
+        accumulator.scriptInputs.push(pattern);
+      }
+      return accumulator;
+    },
+    { scriptInputs: [], args: [] }
+  );
 
-  // TODO: See #41
-  // Customize concurrently to prettify the script outputs and
-  // make it possible to have priority outputs for certain scripts,
-  // e.g. having a server watching script output take priority over
-  // other background watch tasks
-  await concurrently(npmScriptPatterns, {
-    killOthers: ["failure"],
-  });
+  // It is possible that all provided patterns are arguments
+  // without a single script name. In this case an error should
+  // thrown, because no script will be run
+  if (!scriptInputs.length) {
+    throw new Error("No script pattern provided.");
+  }
+
+  // Get all script names from package.json
+  const packageJsonRaw = await fs.readFile(
+    path.join(cwd, PACKAGE_JSON_FILENAME),
+    "utf8"
+  );
+  const packageJson: PackageJson = JSON.parse(packageJsonRaw);
+  const packageJsonScriptNames = Object.keys(packageJson.scripts ?? {});
+  const packageJsonScriptNamesSet = new Set(packageJsonScriptNames);
+
+  const scriptsToRun = scriptInputs.reduce<string[]>(
+    (accumulator, scriptPattern) => {
+      // Script patterns can either be a simple script name
+      // or multiple scripts using a wildcard (*).
+      if (scriptPattern.includes("*")) {
+        // run should use simplistic logic and match all scripts
+        // that start with the part until the first '*' character.
+        //
+        // More sophisticated matching is not needed at this time
+        // since the main use case is for scripts that are merged
+        // by coat. There are other cli tools that can provide
+        // more sophisticated behavior, e.g. concurrently.
+        const scriptPatternPrefix = scriptPattern.split("*")[0];
+        const scriptsForPattern = packageJsonScriptNames.filter((scriptName) =>
+          scriptName.startsWith(scriptPatternPrefix)
+        );
+        if (!scriptsForPattern.length) {
+          // Throw an error when a pattern yields no result to
+          // prevent unintended behavior where a user expected a script
+          // to be run but it did not match any scripts.
+          throw new Error(
+            `No scripts found in package.json for pattern: ${scriptPattern}`
+          );
+        }
+        accumulator.push(...scriptsForPattern);
+      } else {
+        if (!packageJsonScriptNamesSet.has(scriptPattern)) {
+          // Throw an error when a script name is not found to
+          // prevent unintended behavior where a user expected a script
+          // to be run but it did not match any scripts.
+          throw new Error(
+            `No script named "${scriptPattern}" found in package.json`
+          );
+        }
+        accumulator.push(scriptPattern);
+      }
+
+      return accumulator;
+    },
+    []
+  );
+
+  if (scriptsToRun.length === 1) {
+    // If the provided input resolves to a single
+    // script, it should be called in a special
+    // way to inherit the stdio and allow advanced
+    // interaction patterns
+    // e.g. using jest in watch mode
+    await runSingleScript(cwd, scriptsToRun[0], args);
+  } else {
+    await runMultipleScripts(cwd, scriptsToRun, args);
+  }
 }

--- a/packages/cli/src/run/run-multiple-scripts.test.ts
+++ b/packages/cli/src/run/run-multiple-scripts.test.ts
@@ -25,13 +25,13 @@ describe("run/run-multiple-scripts", () => {
       1,
       "npm",
       ["run", "--silent", "script1"],
-      { cwd: "/test", env: { FORCE_COLOR: "true" } }
+      { cwd: testCwd, env: { FORCE_COLOR: "true" } }
     );
     expect(execa).toHaveBeenNthCalledWith(
       2,
       "npm",
       ["run", "--silent", "script2"],
-      { cwd: "/test", env: { FORCE_COLOR: "true" } }
+      { cwd: testCwd, env: { FORCE_COLOR: "true" } }
     );
   });
 
@@ -47,13 +47,13 @@ describe("run/run-multiple-scripts", () => {
       1,
       "npm",
       ["run", "--silent", "script1", "--", "--arg1", "--arg2", "arg2Value"],
-      { cwd: "/test", env: { FORCE_COLOR: "true" } }
+      { cwd: testCwd, env: { FORCE_COLOR: "true" } }
     );
     expect(execa).toHaveBeenNthCalledWith(
       2,
       "npm",
       ["run", "--silent", "script2", "--", "--arg1", "--arg2", "arg2Value"],
-      { cwd: "/test", env: { FORCE_COLOR: "true" } }
+      { cwd: testCwd, env: { FORCE_COLOR: "true" } }
     );
   });
 

--- a/packages/cli/src/run/run-multiple-scripts.test.ts
+++ b/packages/cli/src/run/run-multiple-scripts.test.ts
@@ -1,0 +1,151 @@
+import execa from "execa";
+import path from "path";
+import memoryStreams from "memory-streams";
+import stripAnsi from "strip-ansi";
+import { runMultipleScripts } from "./run-multiple-scripts";
+
+jest.mock("execa");
+
+const platformRoot = path.parse(process.cwd()).root;
+const testCwd = path.join(platformRoot, "test");
+
+const execaMock = (execa as unknown) as jest.Mock;
+execaMock.mockReturnValue({});
+
+describe("run/run-multiple-scripts", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should call multiple scripts without arguments", async () => {
+    await runMultipleScripts(testCwd, ["script1", "script2"]);
+
+    expect(execa).toHaveBeenCalledTimes(2);
+    expect(execa).toHaveBeenNthCalledWith(
+      1,
+      "npm",
+      ["run", "--silent", "script1"],
+      { cwd: "/test", env: { FORCE_COLOR: "true" } }
+    );
+    expect(execa).toHaveBeenNthCalledWith(
+      2,
+      "npm",
+      ["run", "--silent", "script2"],
+      { cwd: "/test", env: { FORCE_COLOR: "true" } }
+    );
+  });
+
+  test("should call multiple scripts with arguments", async () => {
+    await runMultipleScripts(
+      testCwd,
+      ["script1", "script2"],
+      ["--arg1", "--arg2", "arg2Value"]
+    );
+
+    expect(execa).toHaveBeenCalledTimes(2);
+    expect(execa).toHaveBeenNthCalledWith(
+      1,
+      "npm",
+      ["run", "--silent", "script1", "--", "--arg1", "--arg2", "arg2Value"],
+      { cwd: "/test", env: { FORCE_COLOR: "true" } }
+    );
+    expect(execa).toHaveBeenNthCalledWith(
+      2,
+      "npm",
+      ["run", "--silent", "script2", "--", "--arg1", "--arg2", "arg2Value"],
+      { cwd: "/test", env: { FORCE_COLOR: "true" } }
+    );
+  });
+
+  describe("output prefixing", () => {
+    let stdout: memoryStreams.WritableStream;
+    let stderr: memoryStreams.WritableStream;
+    let taskStdout: memoryStreams.ReadableStream;
+    let taskStderr: memoryStreams.ReadableStream;
+
+    let stdoutSpy: jest.SpyInstance;
+    let stderrSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      stdout = new memoryStreams.WritableStream();
+      stderr = new memoryStreams.WritableStream();
+      taskStdout = new memoryStreams.ReadableStream("");
+      taskStderr = new memoryStreams.ReadableStream("");
+
+      stdoutSpy = jest
+        .spyOn(process.stdout, "write")
+        // @ts-expect-error
+        .mockImplementation(stdout.write.bind(stdout));
+      stderrSpy = jest
+        .spyOn(process.stderr, "write")
+        // @ts-expect-error
+        .mockImplementation(stderr.write.bind(stderr));
+
+      execaMock.mockReturnValue({
+        stdout: taskStdout,
+        stderr: taskStderr,
+      });
+    });
+
+    afterEach(() => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    });
+
+    test("should prefix stdout with script name as a label", async () => {
+      await runMultipleScripts(testCwd, ["script-1"]);
+
+      // memory-streams does not contain type defintions for
+      // the append function
+      //
+      // @ts-expect-error
+      taskStdout.append("First line \n");
+      // @ts-expect-error
+      taskStdout.append("Second ");
+      // @ts-expect-error
+      taskStdout.append("line \n");
+      // @ts-expect-error
+      taskStdout.append("Third line \n");
+
+      expect(stderr.toString()).toBe("");
+
+      // Strip colors to have consistent snapshot
+      const stdoutText = stripAnsi(stdout.toString());
+
+      expect(stdoutText).toMatchInlineSnapshot(`
+        "script-1 - First line 
+        script-1 - Second line 
+        script-1 - Third line 
+        "
+      `);
+    });
+
+    test("should prefix stderr with script name as a label", async () => {
+      await runMultipleScripts(testCwd, ["script-1"]);
+
+      // memory-streams does not contain type defintions for
+      // the append function
+      //
+      // @ts-expect-error
+      taskStderr.append("First line \n");
+      // @ts-expect-error
+      taskStderr.append("Second ");
+      // @ts-expect-error
+      taskStderr.append("line \n");
+      // @ts-expect-error
+      taskStderr.append("Third line \n");
+
+      expect(stdout.toString()).toBe("");
+
+      // Strip colors to have consistent snapshot
+      const stderrText = stripAnsi(stderr.toString());
+
+      expect(stderrText).toMatchInlineSnapshot(`
+        "script-1 - First line 
+        script-1 - Second line 
+        script-1 - Third line 
+        "
+      `);
+    });
+  });
+});

--- a/packages/cli/src/run/run-multiple-scripts.ts
+++ b/packages/cli/src/run/run-multiple-scripts.ts
@@ -1,0 +1,121 @@
+import chalk from "chalk";
+import execa from "execa";
+
+/**
+ * Returns a listener function that prefixes
+ * all lines with a certain label and writes
+ * the result to the passed stream.
+ *
+ * The stream should not be asynchrounous, and this
+ * function is currently only able to handle process.stdout
+ * and process.stdin safely.
+ *
+ * The implementation of this function is leaned heavily
+ * on concurrently's prefixing mechanism.
+ * See: https://github.com/kimmobrunfeldt/concurrently/blob/master/src/logger.js#L85
+ *
+ * @param stream The write stream, typically process.stdout or process.stderr
+ * @param prefix The label that will be prepended to each line
+ */
+function createStreamPrefixHandler(
+  stream: NodeJS.WriteStream,
+  prefix: string
+): (data: Buffer) => void {
+  // The first line of a data chunk should
+  // only be prefixed, if the last character
+  // of the previous chunk ended with a new line.
+  //
+  // To prefix the first chunk correctly, lastChar
+  // is initially set to a new line
+  let lastChar = "\n";
+
+  return (data: Buffer) => {
+    // replace some ANSI code that would impact clearing lines
+    // See concurrently issue #70:
+    // https://github.com/kimmobrunfeldt/concurrently/pull/70
+    const text = data.toString().replace(/\u2026/g, "...");
+
+    const lines = text
+      // Split the current chunk by new lines to
+      // modify each line individually
+      .split("\n")
+      .map((line, index, array) => {
+        if (
+          // Prefix all lines except the first and the
+          // last line - which is an empty line for
+          // each chunk
+          (index > 0 && index < array.length - 1) ||
+          // The first line should only be prefixed
+          // if the last character of the previous chunk
+          // was a new line
+          (index === 0 && lastChar === "\n")
+        ) {
+          // Color the prefix label using chalk
+          return `${chalk.dim(`${prefix} - `)}${line}`;
+        }
+
+        // If no prefix is added, the line is returned
+        // unmodified
+        return line;
+      });
+
+    // Set the saved lastChar value to the last
+    // character of the current text chunk to determine
+    // whether the next chunk's first line needs to be prefixed
+    lastChar = text[text.length - 1];
+
+    // Write all lines to the stream.
+    //
+    // Although stream.write is an asynchrounous method,
+    // using it with process.stdout and process.stderr is
+    // synchrounous and does not need to be awaited.
+    stream.write(lines.join("\n"));
+  };
+}
+
+export async function runMultipleScripts(
+  cwd: string,
+  scripts: string[],
+  args?: string[]
+): Promise<void> {
+  // Promise.all is used here to create a
+  // fail fast behavior that exits once the first
+  // script run fails
+  await Promise.all(
+    scripts.map(async (script) => {
+      // Run scripts in silent mode to surpress
+      // any npm specific output
+      const npmArgs = ["run", "--silent", script];
+
+      if (args?.length) {
+        // Add two dashes ("--") in order for npm run
+        // to pick up the arguments
+        npmArgs.push("--", ...args);
+      }
+
+      const task = execa("npm", npmArgs, {
+        cwd,
+        // Setting FORCE_COLOR to true
+        // helps to preserve colored
+        // output in a lot of scenarios,
+        // even though stdio are piped
+        // for these tasks
+        env: { FORCE_COLOR: "true" },
+      });
+
+      // Attach stream handlers that prefix
+      // the outputs to stdout and stderr with
+      // the script's name
+      task.stdout?.on(
+        "data",
+        createStreamPrefixHandler(process.stdout, script)
+      );
+      task.stderr?.on(
+        "data",
+        createStreamPrefixHandler(process.stderr, script)
+      );
+
+      await task;
+    })
+  );
+}

--- a/packages/cli/src/run/run-single-script.test.ts
+++ b/packages/cli/src/run/run-single-script.test.ts
@@ -1,0 +1,42 @@
+import path from "path";
+import execa from "execa";
+import { runSingleScript } from "./run-single-script";
+
+jest.mock("execa");
+
+const platformRoot = path.parse(process.cwd()).root;
+const testCwd = path.join(platformRoot, "test");
+
+describe("run/run-single-script", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should call npm run with silent flag", async () => {
+    await runSingleScript(testCwd, "script");
+
+    expect(execa).toHaveBeenCalledTimes(1);
+    expect(execa).toHaveBeenLastCalledWith(
+      "npm",
+      ["run", "--silent", "script"],
+      {
+        cwd: testCwd,
+        stdio: "inherit",
+      }
+    );
+  });
+
+  test("should add arguments with double dashes", async () => {
+    await runSingleScript(testCwd, "script", ["--arg1", "--arg2", "arg2Value"]);
+
+    expect(execa).toHaveBeenCalledTimes(1);
+    expect(execa).toHaveBeenLastCalledWith(
+      "npm",
+      ["run", "--silent", "script", "--", "--arg1", "--arg2", "arg2Value"],
+      {
+        cwd: testCwd,
+        stdio: "inherit",
+      }
+    );
+  });
+});

--- a/packages/cli/src/run/run-single-script.ts
+++ b/packages/cli/src/run/run-single-script.ts
@@ -1,0 +1,32 @@
+import execa from "execa";
+
+/**
+ * Runs a single npm script from a package.json file
+ * with the provided arguments
+ *
+ * @param cwd The working directory where the script should be run from
+ * @param script The name of npm script
+ * @param args Optional arguments that will be passed to the script
+ */
+export async function runSingleScript(
+  cwd: string,
+  script: string,
+  args?: string[]
+): Promise<void> {
+  // Run scripts in silent mode to surpress
+  // any npm specific output
+  const npmArgs = ["run", "--silent", script];
+
+  if (args?.length) {
+    // Add two dashes ("--") in order for npm run
+    // to pick up the arguments
+    npmArgs.push("--", ...args);
+  }
+
+  await execa("npm", npmArgs, {
+    // Inherit the stdio to enable interactive
+    // use cases like jest's watch mode
+    stdio: "inherit",
+    cwd,
+  });
+}

--- a/packages/cli/test/run/unknown-commands.test.ts
+++ b/packages/cli/test/run/unknown-commands.test.ts
@@ -1,0 +1,117 @@
+import { runCli } from "../utils/run-cli";
+import { runSyncTest } from "../utils/run-cli-test";
+
+describe("run/unknown-commands", () => {
+  test("should run a single script if command is not a known coat command", async () => {
+    const { cwd, task: syncTask } = await runSyncTest({
+      coatManifest: {
+        name: "test",
+        scripts: [
+          {
+            id: "test-script",
+            scriptName: "test-script",
+            run: "echo Running test script",
+          },
+        ],
+      },
+    });
+    await syncTask;
+
+    const { task: runTask } = runCli(["test-script"], cwd);
+    const result = await runTask;
+
+    expect(result.stdout).toContain("Running test script");
+  });
+
+  test("should run a multiple scripts if command is not a known coat command", async () => {
+    const { cwd, task: syncTask } = await runSyncTest({
+      coatManifest: {
+        name: "test",
+        scripts: [
+          {
+            id: "test-script",
+            scriptName: "test-script",
+            run: "echo Running test script 1",
+          },
+          {
+            id: "test-script-2",
+            scriptName: "test-script",
+            run: "echo Running test script 2",
+          },
+        ],
+      },
+    });
+    await syncTask;
+
+    const { task: runTask } = runCli(["test-script:*"], cwd);
+    const result = await runTask;
+
+    expect(result.stdout).toContain("Running test script 1");
+    expect(result.stdout).toContain("Running test script 2");
+  });
+
+  test("should forward the exit code if script fails", async () => {
+    const { cwd, task: syncTask } = await runSyncTest({
+      coatManifest: {
+        name: "test",
+        scripts: [
+          {
+            id: "test-script",
+            scriptName: "test-script",
+            run: "node -e 'process.exit(5)'",
+          },
+        ],
+      },
+    });
+    await syncTask;
+
+    const { task: runTask } = runCli(["test-script"], cwd);
+    try {
+      await runTask;
+      throw new Error("Line should not be reached");
+    } catch (error) {
+      expect(error.exitCode).toBe(5);
+    }
+  });
+
+  test("should fail fast if any of the scripts fails", async () => {
+    const { cwd, task: syncTask } = await runSyncTest({
+      coatManifest: {
+        name: "test",
+        scripts: [
+          {
+            id: "test-script",
+            scriptName: "test-script",
+            run: "node -e 'process.exit(5)'",
+          },
+          {
+            id: "test-script-2",
+            scriptName: "test-script",
+            run: "node -e \"setTimeout(() => console.log('Done'), 15000);\"",
+          },
+        ],
+      },
+    });
+    await syncTask;
+
+    const { task: runTask } = runCli(["test-script:*"], cwd);
+    try {
+      await runTask;
+      throw new Error("Line should not be reached");
+    } catch (error) {
+      expect(error.stdout).not.toContain("Done");
+      expect(error.exitCode).toBe(5);
+    }
+  });
+
+  test("should print unknown command error if error is thrown before any script is run", async () => {
+    try {
+      await runCli(["test-script"]).task;
+    } catch (error) {
+      expect(error.exitCode).toBe(1);
+      expect(error.stderr).toMatchInlineSnapshot(
+        `"error: unknown script or command 'test-script'. See 'coat --help'"`
+      );
+    }
+  });
+});

--- a/packages/cli/test/run/unknown-commands.test.ts
+++ b/packages/cli/test/run/unknown-commands.test.ts
@@ -58,7 +58,7 @@ describe("run/unknown-commands", () => {
           {
             id: "test-script",
             scriptName: "test-script",
-            run: "node -e 'process.exit(5)'",
+            run: 'node -e "process.exit(5);"',
           },
         ],
       },
@@ -82,7 +82,7 @@ describe("run/unknown-commands", () => {
           {
             id: "test-script",
             scriptName: "test-script",
-            run: "node -e 'process.exit(5)'",
+            run: 'node -e "process.exit(5);"',
           },
           {
             id: "test-script-2",


### PR DESCRIPTION
Rewrite of the `coat run` command to no longer use concurrently under the hood but gather and execute npm scripts directly from coat.

NPM scripts will be called with the `--silent` flag to suppress npm output. If the input pattern(s) resolve to a single script, it will be called directly and inherits the calling stdio.

In addition to the `coat run` command, scripts will be run if coat is called with the script name directly, but only if it does not conflict with another built-in coat command.

E.g. running `coat test` will call the npm script "test", because coat does not have a test command itself.

Resolves #40, #41