### PR TITLE
ci: 💚 Change set-env outputs to env file additions

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -59,10 +59,10 @@ jobs:
       - name: Decrease npm retry factors on macOS
         if: matrix.os == 'macos-latest'
         run: |
-          echo "::set-env name=npm_config_fetch_retries::50"
-          echo "::set-env name=npm_config_fetch_retry_factor::2"
-          echo "::set-env name=npm_config_fetch_retry_mintimeout::50"
-          echo "::set-env name=npm_config_fetch_retry_maxtimeout::6000"
+          echo "npm_config_fetch_retries=50" >> $GITHUB_ENV
+          echo "npm_config_fetch_retry_factor=2" >> $GITHUB_ENV
+          echo "npm_config_fetch_retry_mintimeout=50" >> $GITHUB_ENV
+          echo "npm_config_fetch_retry_maxtimeout=6000" >> $GITHUB_ENV
       - name: Run all tests
         run: npm run test:all -- --ci --no-cache --runInBand --verbose
         working-directory: ./packages/cli


### PR DESCRIPTION
GitHub Actions deprecated setting environment variables via set-env outputs and recommends using environment files instead.

More information:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/