### PR TITLE
feat(cli): ✨ Allow merging scripts by id

### DIFF
--- a/packages/cli/src/setup/gather-all-tasks.ts
+++ b/packages/cli/src/setup/gather-all-tasks.ts
@@ -11,19 +11,23 @@ import { CoatManifestStrict } from "../types/coat-manifest";
 function mergeTasks(tasks: CoatManifestTaskStrict[]): CoatManifestTaskStrict[] {
   // If multiple tasks share the same id, the latest task
   // to use the id should replace the earliest task in the array
-  return tasks.reduce<CoatManifestTaskStrict[]>((accumulator, task) => {
-    const savedTaskIndex = accumulator.findIndex(
-      (savedTask) => savedTask.id === task.id
-    );
-    if (savedTaskIndex === -1) {
-      // Task does not exist yet, save it in the resulting array
-      accumulator.push(task);
-    } else {
-      // Replace earlier task with current task version
-      accumulator[savedTaskIndex] = task;
-    }
-    return accumulator;
-  }, []);
+  return tasks.reduce<{
+    result: CoatManifestTaskStrict[];
+    indexMap: Record<string, number>;
+  }>(
+    (accumulator, task) => {
+      const savedTaskIndex = accumulator.indexMap[task.id];
+      if (typeof savedTaskIndex === "undefined") {
+        // Task does not exist yet, save it in the resulting array
+        accumulator.indexMap[task.id] = accumulator.result.push(task) - 1;
+      } else {
+        // Replace earlier task with current task version
+        accumulator.result[savedTaskIndex] = task;
+      }
+      return accumulator;
+    },
+    { result: [], indexMap: {} }
+  ).result;
 }
 
 /**

--- a/packages/cli/src/sync/merge-scripts.test.ts
+++ b/packages/cli/src/sync/merge-scripts.test.ts
@@ -104,4 +104,31 @@ describe("sync/merge-scripts", () => {
       "test:4": "test4",
     });
   });
+
+  test("should use latest entry in scripts array if multiple scripts share the same id", () => {
+    const result = mergeScripts([
+      [
+        {
+          id: "test",
+          run: "test1",
+          scriptName: "test",
+        },
+        {
+          id: "test",
+          run: "test2",
+          scriptName: "test2",
+        },
+      ],
+      [
+        {
+          id: "test",
+          run: "test3",
+          scriptName: "test",
+        },
+      ],
+    ]);
+    expect(result.scripts).toEqual({
+      test: "test3",
+    });
+  });
 });

--- a/packages/cli/src/sync/merge-scripts.ts
+++ b/packages/cli/src/sync/merge-scripts.ts
@@ -1,6 +1,6 @@
-import { uniqBy } from "lodash";
 import flatten from "lodash/flatten";
 import groupBy from "lodash/groupBy";
+import uniqBy from "lodash/uniqBy";
 import { CoatManifestStrict } from "../types/coat-manifest";
 
 /**

--- a/packages/cli/src/sync/merge-scripts.ts
+++ b/packages/cli/src/sync/merge-scripts.ts
@@ -1,3 +1,4 @@
+import { uniqBy } from "lodash";
 import flatten from "lodash/flatten";
 import groupBy from "lodash/groupBy";
 import { CoatManifestStrict } from "../types/coat-manifest";
@@ -19,8 +20,11 @@ export function mergeScripts(
   scripts: Record<string, string>;
   parallelScriptPrefixes: string[];
 } {
+  // Use the latest script entry for scripts that share the same id
+  const uniqueScripts = uniqBy(flatten(scripts).reverse(), "id");
+
   // Group scripts by scriptName
-  const groupedScripts = groupBy(flatten(scripts), "scriptName");
+  const groupedScripts = groupBy(uniqueScripts, "scriptName");
 
   return Object.entries(groupedScripts).reduce<{
     scripts: Record<string, string>;


### PR DESCRIPTION
Allows to override existing scripts that are provided by templates by specifying a script with the same id.

This can be useful in situations where a later template wants to override an existing script because the script command needs to be adjusted.