### PR TITLE
feat: 🛠 Remove automatic prepare step

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -15,17 +15,19 @@ jobs:
           npx --no-install lerna bootstrap
       - name: Lint
         run: npx --no-install lerna run lint --stream
+      - name: Build
+        run: npx --no-install lerna run build --stream
       - name: Test
         run: |
           npx --no-install lerna run test --stream -- -- \
-          --ci \
-          --no-cache \
-          --runInBand \
-          --verbose \
-          --coverageReporters json \
-          --coverageReporters lcov \
-          --coverageReporters text \
-          --coverageReporters clover
+            --ci \
+            --no-cache \
+            --runInBand \
+            --verbose \
+            --coverageReporters json \
+            --coverageReporters lcov \
+            --coverageReporters text \
+            --coverageReporters clover
       - name: Upload test coverage information
         run: bash <(curl -s https://codecov.io/bash)
       - name: Build package artifacts

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -13,10 +13,10 @@ jobs:
         run: |
           npm ci
           npx --no-install lerna bootstrap
-      - name: Lint
-        run: npx --no-install lerna run lint --stream
       - name: Build
         run: npx --no-install lerna run build --stream
+      - name: Lint
+        run: npx --no-install lerna run lint --stream
       - name: Test
         run: |
           npx --no-install lerna run test --stream -- -- \

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -75,7 +75,6 @@
     "lint:prettier": "prettier --check src test",
     "lint:tsc": "tsc",
     "prebuild": "rm -rf build",
-    "prepare": "npm run build",
     "prepack": "cross-env BABEL_ENV=production npm run build",
     "test": "cross-env JEST_PROJECT=\"Unit tests\" jest",
     "test:e2e": "cross-env JEST_PROJECT=\"E2E tests\" jest --coverage=false",

--- a/packages/template-ts-package/coat.lock
+++ b/packages/template-ts-package/coat.lock
@@ -41,13 +41,12 @@ files:
     path: tsconfig.json
 scripts:
   - build
-  - "build:babel"
-  - "build:typedefs"
+  - build:babel
+  - build:typedefs
   - lint
-  - "lint:eslint"
-  - "lint:prettier"
-  - "lint:types"
+  - lint:eslint
+  - lint:prettier
+  - lint:types
   - prebuild
-  - prepare
   - test
 version: 1

--- a/packages/template-ts-package/package.json
+++ b/packages/template-ts-package/package.json
@@ -47,7 +47,6 @@
     "lint:prettier": "prettier --check src",
     "lint:types": "tsc",
     "prebuild": "rimraf build",
-    "prepare": "coat run build && coat sync",
     "test": "jest",
     "watch-build": "coat run npm:watch-build:*",
     "watch-build:babel": "npm run build:babel -- --watch",

--- a/packages/template-ts-package/package.json-custom.js
+++ b/packages/template-ts-package/package.json-custom.js
@@ -1,13 +1,8 @@
 module.exports = (packageJson) => {
   const newPackageJson = {
     ...packageJson,
-    scripts: {
-      ...packageJson.scripts,
-    },
     files: ["build/", "files/"],
   };
-
-  newPackageJson.scripts.prepare = "coat run build && coat sync";
 
   return newPackageJson;
 };

--- a/packages/template-ts-package/src/__snapshots__/index.test.ts.snap
+++ b/packages/template-ts-package/src/__snapshots__/index.test.ts.snap
@@ -245,7 +245,6 @@ scripts:
   - lint:prettier
   - lint:types
   - prebuild
-  - prepare
   - test
 version: 1
 "
@@ -297,7 +296,6 @@ exports[`@coat/template-ts-package template verification - babel compiler 8`] = 
     \\"lint:prettier\\": \\"prettier --check src\\",
     \\"lint:types\\": \\"tsc\\",
     \\"prebuild\\": \\"rimraf build\\",
-    \\"prepare\\": \\"coat sync && coat run build\\",
     \\"test\\": \\"jest\\"
   }
 }
@@ -584,7 +582,6 @@ scripts:
   - lint:prettier
   - lint:types
   - prebuild
-  - prepare
   - test
 version: 1
 "
@@ -632,7 +629,6 @@ exports[`@coat/template-ts-package template verification - default config 7`] = 
     \\"lint:prettier\\": \\"prettier --check src\\",
     \\"lint:types\\": \\"tsc\\",
     \\"prebuild\\": \\"rimraf build\\",
-    \\"prepare\\": \\"coat sync && coat run build\\",
     \\"test\\": \\"jest\\"
   }
 }
@@ -916,7 +912,6 @@ scripts:
   - lint:prettier
   - lint:types
   - prebuild
-  - prepare
   - test
 version: 1
 "
@@ -964,7 +959,6 @@ exports[`@coat/template-ts-package template verification - typescript compiler 7
     \\"lint:prettier\\": \\"prettier --check src\\",
     \\"lint:types\\": \\"tsc\\",
     \\"prebuild\\": \\"rimraf build\\",
-    \\"prepare\\": \\"coat sync && coat run build\\",
     \\"test\\": \\"jest\\"
   }
 }

--- a/packages/template-ts-package/src/index.ts
+++ b/packages/template-ts-package/src/index.ts
@@ -140,11 +140,6 @@ const createTemplate: CoatTemplate = ({ coatContext, config: userConfig }) => {
       run: "jest",
       scriptName: "test",
     },
-    {
-      id: "prepare-sync-and-build",
-      run: "coat sync && coat run build",
-      scriptName: "prepare",
-    },
   ];
 
   switch (config.compiler) {


### PR DESCRIPTION
Removes the automatic prepare step of the cli and template-ts-package. The step is also removed from coat projects that are based on template-ts-package.

While the prepare step made it simpler to get started with a project without running any additional commands, it also forced users to run certain lifecycle scripts like builds or coat syncs even though they just wanted to execute other scripts (e.g. lint or test).