### PR TITLE
fix(template-ts-package): 🔨 Ignore build folder in TypeScript project

### DIFF
--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -3,7 +3,6 @@
     "isolatedModules": false,
     "emitDeclarationOnly": true,
     "declaration": true,
-    "outDir": "build",
     "noEmit": false
   },
   "exclude": ["**/*.test.ts"],

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,7 +11,7 @@
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "strict": true,
+    "outDir": "build",
     "target": "esnext"
-  },
-  "exclude": ["build"]
+  }
 }

--- a/packages/template-ts-package/coat.lock
+++ b/packages/template-ts-package/coat.lock
@@ -34,19 +34,19 @@ files:
   - once: true
     path: src/index.ts
   - hash: >-
-      Wvn79Ah1EmIDyTVVi4uDZAucomOUsQXNPCqWdj1KXckHWjaLhGHD4rwesjGVVa/0FM9rEvtFq1OsiftbNpA1hw==
+      dEjl1diD30UVpPa+Eqopj6sUzG4fZFuRB3Yw9DRQMnrlFJzFralwcjSjCph7gJT89UmQiE/UO6zwaoKB7e5jEA==
     path: tsconfig.build.json
   - hash: >-
-      mmM9PGwqLSxLRIDBzKFNtJqqM/1Fh/TOzubHlC6su7WHv1peDWQglI014mldKMdHNri6F4wbp5NGN26XCTHkFw==
+      hJ6j7yCY25tYeYP5U7xfPlPmTWlkI6yoYOoBB2hyYbyPAf+xiYQ+mkX9QWa2tCTFtYyuwsPQ12VZD3AjV5Rylg==
     path: tsconfig.json
 scripts:
   - build
-  - build:babel
-  - build:typedefs
+  - "build:babel"
+  - "build:typedefs"
   - lint
-  - lint:eslint
-  - lint:prettier
-  - lint:types
+  - "lint:eslint"
+  - "lint:prettier"
+  - "lint:types"
   - prebuild
   - test
 version: 1

--- a/packages/template-ts-package/files/shared/tsconfig.build.json
+++ b/packages/template-ts-package/files/shared/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "outDir": "build",
     "noEmit": false
   },
   "include": ["src"],

--- a/packages/template-ts-package/files/shared/tsconfig.json
+++ b/packages/template-ts-package/files/shared/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "lib": ["DOM", "ES5", "ScriptHost", "ES2015"],
     "noEmit": true,
+    "outDir": "build",
     "forceConsistentCasingInFileNames": true
   }
 }

--- a/packages/template-ts-package/src/__snapshots__/index.test.ts.snap
+++ b/packages/template-ts-package/src/__snapshots__/index.test.ts.snap
@@ -231,10 +231,10 @@ files:
   - once: true
     path: src/index.ts
   - hash: >-
-      Wvn79Ah1EmIDyTVVi4uDZAucomOUsQXNPCqWdj1KXckHWjaLhGHD4rwesjGVVa/0FM9rEvtFq1OsiftbNpA1hw==
+      dEjl1diD30UVpPa+Eqopj6sUzG4fZFuRB3Yw9DRQMnrlFJzFralwcjSjCph7gJT89UmQiE/UO6zwaoKB7e5jEA==
     path: tsconfig.build.json
   - hash: >-
-      mmM9PGwqLSxLRIDBzKFNtJqqM/1Fh/TOzubHlC6su7WHv1peDWQglI014mldKMdHNri6F4wbp5NGN26XCTHkFw==
+      hJ6j7yCY25tYeYP5U7xfPlPmTWlkI6yoYOoBB2hyYbyPAf+xiYQ+mkX9QWa2tCTFtYyuwsPQ12VZD3AjV5Rylg==
     path: tsconfig.json
 scripts:
   - build
@@ -335,8 +335,7 @@ exports[`@coat/template-ts-package template verification - babel compiler 11`] =
     \\"declaration\\": true,
     \\"emitDeclarationOnly\\": true,
     \\"isolatedModules\\": false,
-    \\"noEmit\\": false,
-    \\"outDir\\": \\"build\\"
+    \\"noEmit\\": false
   },
   \\"exclude\\": [\\"**/**/*.test.ts\\"],
   \\"extends\\": \\"./tsconfig.json\\",
@@ -357,6 +356,7 @@ exports[`@coat/template-ts-package template verification - babel compiler 12`] =
     \\"module\\": \\"commonjs\\",
     \\"moduleResolution\\": \\"node\\",
     \\"noEmit\\": true,
+    \\"outDir\\": \\"build\\",
     \\"strict\\": true,
     \\"target\\": \\"ESNext\\"
   }
@@ -570,10 +570,10 @@ files:
   - once: true
     path: src/index.ts
   - hash: >-
-      iBs7gseJaH2TqwMp681kwDfa9zzT+kVDtATXxQC0SuMRXhT4YBYD+gTD4UKz9Njr8qswfAZIsIhvYSeCGkXTiA==
+      zN51ATJNBuF7EqPvKtnvN8DjhfuWBsojjSkOl2y67qI9j8LmkNmsh0DBkLk3qDJm8dQ025+bGUNNfZBmxx81Gg==
     path: tsconfig.build.json
   - hash: >-
-      0XSVaBRUX42h0NJUywD/vWuY/Y0BT0TFOkSQcdwTpsu7ncfmkYEmyYC3L08VH6JXCOiy+MpWcmV3arT1ZwEu9Q==
+      baIFGU4pqXu749Y7zvK1NP/VzP27ZlZ0TrsD86m3alSj0LHNsrZp+On4Rod2U299a2NkQykBpjpKbBBJTtvQqA==
     path: tsconfig.json
 scripts:
   - build
@@ -666,8 +666,7 @@ exports[`@coat/template-ts-package template verification - default config 10`] =
 {
   \\"compilerOptions\\": {
     \\"declaration\\": true,
-    \\"noEmit\\": false,
-    \\"outDir\\": \\"build\\"
+    \\"noEmit\\": false
   },
   \\"exclude\\": [\\"**/**/*.test.ts\\"],
   \\"extends\\": \\"./tsconfig.json\\",
@@ -687,6 +686,7 @@ exports[`@coat/template-ts-package template verification - default config 11`] =
     \\"module\\": \\"commonjs\\",
     \\"moduleResolution\\": \\"node\\",
     \\"noEmit\\": true,
+    \\"outDir\\": \\"build\\",
     \\"strict\\": true,
     \\"target\\": \\"ES2018\\"
   }
@@ -900,10 +900,10 @@ files:
   - once: true
     path: src/index.ts
   - hash: >-
-      iBs7gseJaH2TqwMp681kwDfa9zzT+kVDtATXxQC0SuMRXhT4YBYD+gTD4UKz9Njr8qswfAZIsIhvYSeCGkXTiA==
+      zN51ATJNBuF7EqPvKtnvN8DjhfuWBsojjSkOl2y67qI9j8LmkNmsh0DBkLk3qDJm8dQ025+bGUNNfZBmxx81Gg==
     path: tsconfig.build.json
   - hash: >-
-      0XSVaBRUX42h0NJUywD/vWuY/Y0BT0TFOkSQcdwTpsu7ncfmkYEmyYC3L08VH6JXCOiy+MpWcmV3arT1ZwEu9Q==
+      baIFGU4pqXu749Y7zvK1NP/VzP27ZlZ0TrsD86m3alSj0LHNsrZp+On4Rod2U299a2NkQykBpjpKbBBJTtvQqA==
     path: tsconfig.json
 scripts:
   - build
@@ -996,8 +996,7 @@ exports[`@coat/template-ts-package template verification - typescript compiler 1
 {
   \\"compilerOptions\\": {
     \\"declaration\\": true,
-    \\"noEmit\\": false,
-    \\"outDir\\": \\"build\\"
+    \\"noEmit\\": false
   },
   \\"exclude\\": [\\"**/**/*.test.ts\\"],
   \\"extends\\": \\"./tsconfig.json\\",
@@ -1017,6 +1016,7 @@ exports[`@coat/template-ts-package template verification - typescript compiler 1
     \\"module\\": \\"commonjs\\",
     \\"moduleResolution\\": \\"node\\",
     \\"noEmit\\": true,
+    \\"outDir\\": \\"build\\",
     \\"strict\\": true,
     \\"target\\": \\"ES2018\\"
   }

--- a/packages/template-ts-package/tsconfig.build.json
+++ b/packages/template-ts-package/tsconfig.build.json
@@ -3,8 +3,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "isolatedModules": false,
-    "noEmit": false,
-    "outDir": "build"
+    "noEmit": false
   },
   "exclude": ["**/**/*.test.ts"],
   "extends": "./tsconfig.json",

--- a/packages/template-ts-package/tsconfig.json
+++ b/packages/template-ts-package/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,
+    "outDir": "build",
     "strict": true,
     "target": "ESNext"
   }


### PR DESCRIPTION
TypeScript picks up types from the build folder, which lead to duplicated type issues and errors.

This happened since a coat project based on template-ts-package has two tsconfig files - a generic config (`tsconfig.json`) for development and a build config (`tsconfig.build.json`) for building the types.

Since TypeScript excludes the value of the `compilerOptions.outDir` by default, the property was moved from the build config to the generic config, since the build config extends the generic config.

Fixes #86