### PR TITLE
feat(cli): 💄 Add coat logo to help output

### DIFF
--- a/packages/cli/src/bin/cli.ts
+++ b/packages/cli/src/bin/cli.ts
@@ -4,6 +4,7 @@ import { create } from "../create";
 import { run } from "../run";
 import { setup } from "../setup";
 import { sync } from "../sync";
+import { getCoatHeader } from "./get-coat-header";
 
 /**
  * Creates a command CLI program to run coat commands
@@ -96,6 +97,9 @@ export function createProgram(): InstanceType<CommandConstructor> {
       }
     }
   });
+
+  // Add coat logo to help command output
+  program.addHelpText("beforeAll", getCoatHeader());
 
   return program;
 }

--- a/packages/cli/src/bin/get-coat-header.test.ts
+++ b/packages/cli/src/bin/get-coat-header.test.ts
@@ -1,0 +1,43 @@
+import chalk from "chalk";
+import {
+  getUsableTerminalSize,
+  TerminalSize,
+} from "../ui/get-usable-terminal-size";
+import { getCoatHeader } from "./get-coat-header";
+
+jest.mock("../ui/get-usable-terminal-size");
+
+const getUsableTerminalSizeSpy = getUsableTerminalSize as jest.Mock<
+  ReturnType<typeof getUsableTerminalSize>
+>;
+
+describe("create/print-create-customization-help", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getCoatHeader", () => {
+    test("should return small header when terminal is tiny", () => {
+      getUsableTerminalSizeSpy.mockReturnValue({
+        size: TerminalSize.Tiny,
+        width: 0,
+      });
+
+      const header = getCoatHeader();
+      expect(header).toBe(`\n🚀 ${chalk.cyan("coat")} 🚀\n`);
+    });
+
+    test("should return full logo box when terminal is small", () => {
+      getUsableTerminalSizeSpy.mockReturnValue({
+        size: TerminalSize.Small,
+        width: 58,
+      });
+
+      const header = getCoatHeader();
+      // Only assert that console has been called
+      // and that it has not been called with the small logo
+      // since the logo box is too complex
+      expect(header).not.toBe(`\n🚀 ${chalk.cyan("coat")} 🚀\n`);
+    });
+  });
+});

--- a/packages/cli/src/bin/get-coat-header.ts
+++ b/packages/cli/src/bin/get-coat-header.ts
@@ -1,0 +1,23 @@
+import chalk from "chalk";
+import {
+  getUsableTerminalSize,
+  TerminalSize,
+} from "../ui/get-usable-terminal-size";
+import { createCoatLogo } from "../ui/create-coat-logo";
+
+/**
+ * Returns the coat logo, description and the website url in
+ * a pretty box.
+ * On tiny terminal sizes, a shorter version is returned.
+ */
+
+export function getCoatHeader(): string {
+  const usableTerminalSize = getUsableTerminalSize(process.stdout);
+
+  if (usableTerminalSize.size === TerminalSize.Tiny) {
+    const tinyLogo = `🚀 ${chalk.cyan("coat")} 🚀`;
+    return `\n${tinyLogo}\n`;
+  } else {
+    return createCoatLogo();
+  }
+}

--- a/packages/cli/src/create/index.test.ts
+++ b/packages/cli/src/create/index.test.ts
@@ -21,7 +21,8 @@ jest
   .mock("./get-template-info")
   .mock("./get-project-name")
   .mock("./add-initial-commit")
-  .mock("./print-create-messages")
+  .mock("./print-create-customization-help")
+  .mock("../bin/get-coat-header")
   .mock("../sync");
 
 const execaMock = (execa as unknown) as jest.Mock;

--- a/packages/cli/src/create/index.ts
+++ b/packages/cli/src/create/index.ts
@@ -14,10 +14,8 @@ import {
 } from "../constants";
 import { polish as jsonPolish } from "../file-types/json";
 import { addInitialCommit } from "./add-initial-commit";
-import {
-  printCreateCustomizationHelp,
-  printCreateHeader,
-} from "./print-create-messages";
+import { printCreateCustomizationHelp } from "./print-create-customization-help";
+import { getCoatHeader } from "../bin/get-coat-header";
 
 /**
  * Creates and generates a new coat project.
@@ -31,8 +29,8 @@ export async function create(
   directoryInputUnsanitized?: string,
   projectNameInputUnsanitized?: string
 ): Promise<void> {
-  // Prints the coat logo and header
-  printCreateHeader();
+  // Print the coat logo and header
+  console.log(getCoatHeader());
 
   const directoryInput = directoryInputUnsanitized?.trim();
   const projectNameInput = projectNameInputUnsanitized?.trim();

--- a/packages/cli/src/create/print-create-customization-help.test.ts
+++ b/packages/cli/src/create/print-create-customization-help.test.ts
@@ -1,12 +1,8 @@
-import chalk from "chalk";
 import {
   getUsableTerminalSize,
   TerminalSize,
 } from "../ui/get-usable-terminal-size";
-import {
-  printCreateCustomizationHelp,
-  printCreateHeader,
-} from "./print-create-messages";
+import { printCreateCustomizationHelp } from "./print-create-customization-help";
 
 jest.mock("../ui/get-usable-terminal-size");
 
@@ -16,40 +12,9 @@ const getUsableTerminalSizeSpy = getUsableTerminalSize as jest.Mock<
   ReturnType<typeof getUsableTerminalSize>
 >;
 
-describe("create/print-create-messages", () => {
+describe("create/print-create-customization-help", () => {
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  describe("printCreateHeader", () => {
-    test("should print small header when terminal is tiny", () => {
-      getUsableTerminalSizeSpy.mockReturnValue({
-        size: TerminalSize.Tiny,
-        width: 0,
-      });
-
-      printCreateHeader();
-      expect(consoleSpy).toHaveBeenCalledTimes(1);
-      expect(consoleSpy).toHaveBeenLastCalledWith(
-        `\n🚀 ${chalk.cyan("coat")} 🚀`
-      );
-    });
-
-    test("should print full logo box when terminal is small", () => {
-      getUsableTerminalSizeSpy.mockReturnValue({
-        size: TerminalSize.Small,
-        width: 58,
-      });
-
-      printCreateHeader();
-      // Only assert that console has been called
-      // and that it has not been called with the small logo
-      // since the logo box is too complex
-      expect(consoleSpy).toHaveBeenCalledTimes(1);
-      expect(consoleSpy).not.toHaveBeenCalledWith(
-        `\n🚀 ${chalk.cyan("coat")} 🚀`
-      );
-    });
   });
 
   describe("printCreateCustomizationHelp", () => {

--- a/packages/cli/src/create/print-create-customization-help.ts
+++ b/packages/cli/src/create/print-create-customization-help.ts
@@ -8,23 +8,6 @@ import {
   TerminalSize,
 } from "../ui/get-usable-terminal-size";
 import { fillLastLine } from "../ui/fill-last-line";
-import { createCoatLogo } from "../ui/create-coat-logo";
-
-/**
- * Prints the coat logo, description and the website url in
- * a pretty box.
- * On tiny terminal sizes, a shorter version is printed.
- */
-export function printCreateHeader(): void {
-  const usableTerminalSize = getUsableTerminalSize(process.stdout);
-
-  if (usableTerminalSize.size === TerminalSize.Tiny) {
-    const tinyLogo = `🚀 ${chalk.cyan("coat")} 🚀`;
-    console.log(`\n${tinyLogo}`);
-  } else {
-    console.log(createCoatLogo());
-  }
-}
 
 /**
  * Prints getting started guidance for the customization of the generated

--- a/packages/cli/test/setup/general.test.ts
+++ b/packages/cli/test/setup/general.test.ts
@@ -20,16 +20,15 @@ describe("setup - general", () => {
     ]);
 
     expect(helpArgument.stdout).toEqual(helpCommand.stdout);
-    expect(helpArgument.stdout).toMatchInlineSnapshot(`
-      "Usage: coat setup [options]
 
-      Runs all setup tasks of the current coat project
-
-      Options:
-        -h, --help  
-        
-        Gathers all setup tasks of the extended templates and runs them in sequential order."
-    `);
+    const helpLines = [
+      "Usage: coat setup [options]",
+      "Runs all setup tasks of the current coat project",
+      "Gathers all setup tasks of the extended templates and runs them in sequential order.",
+    ];
+    helpLines.forEach((helpLine) => {
+      expect(helpArgument.stdout).toContain(helpLine);
+    });
   });
 
   test("should run all tasks in a fresh coat project", async () => {

--- a/packages/cli/test/sync/general.test.ts
+++ b/packages/cli/test/sync/general.test.ts
@@ -16,18 +16,16 @@ describe("coat sync - general", () => {
     ]);
 
     expect(helpArgument.stdout).toEqual(helpCommand.stdout);
-    expect(helpArgument.stdout).toMatchInlineSnapshot(`
-      "Usage: coat sync [options]
 
-      Generates all files of the current coat project.
-
-      Options:
-        -h, --help  
-        
-        Gathers all files of the extended templates, merges them and places them in the project directory.
-        
-        Generated files can be extended by placing a file next to it with the \\"-custom.js\\" suffix and exporting a function that returns the customized content."
-    `);
+    const helpLines = [
+      "Usage: coat sync [options]",
+      "Generates all files of the current coat project.",
+      "Gathers all files of the extended templates, merges them and places them in the project directory.",
+      'Generated files can be extended by placing a file next to it with the "-custom.js" suffix and exporting a function that returns the customized content.',
+    ];
+    helpLines.forEach((helpLine) => {
+      expect(helpArgument.stdout).toContain(helpLine);
+    });
   });
 
   test("should not run sync when help function is called", async () => {


### PR DESCRIPTION
Adds the coat ASCII logo to help command outputs, e.g. when running:

```
coat help
coat sync --help
```

Fixes #110 [CLI] Add coat logo to help output