### PR TITLE
feat(cli): ✨ Support npm v7

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -1,14 +1,18 @@
 name: "@coat/cli"
 on: push
-
+env:
+  FORCE_COLOR: 3
 jobs:
   build:
     name: Lint, Test & Build
     runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: 3
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install latest npm version
+        run: npm install --global npm
       - name: Install dependencies
         run: |
           npm ci
@@ -43,15 +47,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [10, 12, 14]
+        node: [10, 12, 14, 15]
     runs-on: ${{ matrix.os }}
-    env:
-      FORCE_COLOR: 3
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+      - name: Install latest npm version
+        run: npm install --global npm
       - name: Install dependencies
         run: |
           npm ci

--- a/packages/cli/bin/coat.js
+++ b/packages/cli/bin/coat.js
@@ -5,7 +5,7 @@
 //
 // While this code is not covered by unit tests
 // and code coverage, e2e tests
-// in /tests will run this code since they
+// in /tests will run this code since they run
 // node with this file as the main module
 //
 // TODO: See #14

--- a/packages/cli/src/create/get-template-info.ts
+++ b/packages/cli/src/create/get-template-info.ts
@@ -46,7 +46,7 @@ export async function getTemplateInfo(
   };
 
   // Get the name of the new devDependency that has been installed
-  // to get the correct template name by comparing current devDepndencies
+  // to get the correct template name by comparing current devDependencies
   // to the previous devDependencies.
   // Since only a single dependency - the template itself - was installed,
   // it should be the only entry in the difference array
@@ -114,7 +114,7 @@ export async function getTemplateInfo(
     `${tmpTemplatePackageName}/${PACKAGE_JSON_FILENAME}`
   ) as PackageJson;
 
-  // Remove temporary directory
+  // Remove the temporary directory
   tmpDir.removeCallback();
 
   return templateInfo;

--- a/packages/cli/src/create/get-template-info.ts
+++ b/packages/cli/src/create/get-template-info.ts
@@ -71,7 +71,7 @@ export async function getTemplateInfo(
   // eslint-disable-next-line no-param-reassign
   installSpinner.text = `${chalk.cyan(
     "coat"
-  )} was not able to determine the template name and peerDependencies directly by installing the template and has to do an extra round to retrieve information about the installed template.\nThis is likely due to the template already being installed in the project directory before. This might take a couple of minutes.\n`;
+  )} was not able to determine the template name directly by installing the template and has to do an extra round to retrieve information about the installed template.\nThis is likely due to the template already being installed in the project directory before. This might take a couple of minutes.\n`;
   //
   // Create a temporary directory
   const tmpDir = tmp.dirSync({ unsafeCleanup: true });

--- a/packages/cli/src/create/index.test.ts
+++ b/packages/cli/src/create/index.test.ts
@@ -207,7 +207,7 @@ describe("create", () => {
     );
   });
 
-  test("should add the template and its peerDependencies as devDependencies in the target dir", async () => {
+  test("should add the template as a devDependency in the target dir", async () => {
     (getTemplateInfo as jest.Mock).mockImplementationOnce(() => ({
       name: "template",
       peerDependencies: {
@@ -217,17 +217,10 @@ describe("create", () => {
     }));
     await create({ template: "template", directory: "project-name" });
 
-    expect(execa).toHaveBeenCalledTimes(4);
+    expect(execa).toHaveBeenCalledTimes(3);
     expect(execa).toHaveBeenCalledWith(
       "npm",
       ["install", "--save-exact", "--save-dev", "template"],
-      {
-        cwd: path.join(process.cwd(), "project-name"),
-      }
-    );
-    expect(execa).toHaveBeenCalledWith(
-      "npm",
-      ["install", "--save-dev", "peer-a@^0.0.1", "peer-b@*"],
       {
         cwd: path.join(process.cwd(), "project-name"),
       }

--- a/packages/cli/src/create/index.ts
+++ b/packages/cli/src/create/index.ts
@@ -175,16 +175,9 @@ export async function create({
       cwd: targetCwd,
     });
 
-    // Templates should have a peerDependency on @coat/cli which could
-    // differ from the version which is currently being run.
-    //
-    // In order to run setup and sync with the correct @coat/cli version
-    // peerDependencies of the template should be retrieved and installed
-    // as devDependencies in the project.
-    //
-    // In addition to the peerDependencies, the templateInfo is also required
-    // to get the resolves template name, since the template string that has
-    // been passed to coat could also be a local file path,
+    // We need to retrieve the correct template name,
+    // since the template string that has been passed
+    // to coat create could also be a local file path,
     // GitHub URL or npm tag
     const templateInfo = await getTemplateInfo(
       targetCwd,
@@ -192,20 +185,7 @@ export async function create({
       template,
       installSpinner
     );
-    const peerDependenciesEntries = Object.entries(
-      templateInfo.peerDependencies || {}
-    );
-    if (peerDependenciesEntries.length) {
-      const peerDependencyPackages = peerDependenciesEntries.map(
-        ([packageName, packageVersion]) => `${packageName}@${packageVersion}`
-      );
-      await execa("npm", ["install", "--save-dev", ...peerDependencyPackages], {
-        cwd: targetCwd,
-      });
-    } else {
-      // TODO: See #15
-      // Warn that templates should have a peerDependency on @coat/cli
-    }
+
     installSpinner.succeed();
 
     // Write the coat manifest file

--- a/packages/cli/test/create/project-files.test.ts
+++ b/packages/cli/test/create/project-files.test.ts
@@ -29,9 +29,6 @@ describe("coat create - project files", () => {
       expect(packageJson.devDependencies?.["@coat/e2e-test-template"]).toBe(
         "2.0.0"
       );
-
-      // should add peerDependencies as devDependencies
-      expect(packageJson.devDependencies?.["no-op"]).toBe("^1.0.3");
     });
 
     test("should add the template with GitHub url as devDependency", async () => {
@@ -50,7 +47,6 @@ describe("coat create - project files", () => {
       const packageJson = JSON.parse(packageJsonRaw);
       expect(packageJson.devDependencies).toEqual({
         "@coat/e2e-test-template": "github:coat-dev/cli-e2e-tests-template",
-        "no-op": "^1.0.3",
       });
     });
   });

--- a/packages/cli/test/sync/dependencies.test.ts
+++ b/packages/cli/test/sync/dependencies.test.ts
@@ -107,9 +107,9 @@ describe("coat sync - dependencies", () => {
     ${"dependencies"}         | ${true}
     ${"devDependencies"}      | ${true}
     ${"optionalDependencies"} | ${true}
-    ${"peerDependencies"}     | ${false}
+    ${"peerDependencies"}     | ${true}
   `(
-    "should add a new $dependencyType",
+    "should add new $dependencyType",
     async ({ dependencyType, expectNodeModules }) => {
       const projectName = "test-project";
 
@@ -206,7 +206,7 @@ describe("coat sync - dependencies", () => {
     expect(nodeModules).toContain("local-dependency");
     expect(nodeModules).toContain("local-dependency-dev");
     expect(nodeModules).toContain("local-dependency-optional");
-    expect(nodeModules).not.toContain("local-dependency-peer");
+    expect(nodeModules).toContain("local-dependency-peer");
   });
 
   test("should install dependencies when a dependency is removed", async () => {
@@ -422,7 +422,7 @@ describe("coat sync - dependencies", () => {
     expect(nodeModules).toContain("local-dependency");
     expect(nodeModules).toContain("local-dependency-dev");
     expect(nodeModules).toContain("local-dependency-optional");
-    expect(nodeModules).not.toContain("local-dependency-peer");
+    expect(nodeModules).toContain("local-dependency-peer");
 
     // Update coat manifest to remove all dependency entries again
     await fs.writeFile(

--- a/packages/cli/test/sync/flows.test.ts
+++ b/packages/cli/test/sync/flows.test.ts
@@ -56,6 +56,7 @@ describe("sync/flows", () => {
         CREATED  global.json
         CREATED  local-once.json
         CREATED  local.json
+        UPDATED  package.json
       "
     `);
 


### PR DESCRIPTION
Adds support for npm 7 by accounting for its breaking changes.

npm@7 installs `peerDependencies` automatically, therefore coat will no longer install them manually.