### PR TITLE
feat(cli): ✨ Run local cli if installed in a project

### DIFF
--- a/packages/cli/bin/coat.js
+++ b/packages/cli/bin/coat.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-var-requires */
+//
 // The bin file for the @coat/cli package is not transpiled,
 // since lerna does not correctly symlink the bin file
 // if it is transpiled during the bootstrapping process
@@ -8,15 +10,16 @@
 // in /tests will run this code since they run
 // node with this file as the main module
 //
-// TODO: See #14
+const importLocal = require("import-local");
+
 // Run local version of coat if installed in a project
+if (!importLocal(__filename)) {
+  const { createProgram } = require("../build/bin/cli");
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { createProgram } = require("../build/bin/cli");
-
-createProgram()
-  .parseAsync(process.argv)
-  .catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
+  createProgram()
+    .parseAsync(process.argv)
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -16,6 +16,7 @@
 				"fs-extra": "9.1.0",
 				"immer": "8.0.1",
 				"import-from": "3.0.0",
+				"import-local": "3.0.2",
 				"inquirer": "7.3.3",
 				"js-yaml": "4.0.0",
 				"json-colorizer": "2.2.2",
@@ -5052,7 +5053,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
 			"dependencies": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
@@ -5590,7 +5590,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
 			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
-			"dev": true,
 			"dependencies": {
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
@@ -7410,7 +7409,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
 			"dependencies": {
 				"p-locate": "^4.1.0"
 			},
@@ -7992,7 +7990,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
 			"dependencies": {
 				"p-try": "^2.0.0"
 			},
@@ -8007,7 +8004,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
 			"dependencies": {
 				"p-limit": "^2.2.0"
 			},
@@ -8019,7 +8015,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -8080,7 +8075,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -8159,7 +8153,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
 			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
 			"dependencies": {
 				"find-up": "^4.0.0"
 			},
@@ -8687,7 +8680,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
 			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-			"dev": true,
 			"dependencies": {
 				"resolve-from": "^5.0.0"
 			},
@@ -14313,7 +14305,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
 			"requires": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
@@ -14709,7 +14700,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
 			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
@@ -16150,7 +16140,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
 			"requires": {
 				"p-locate": "^4.1.0"
 			}
@@ -16625,7 +16614,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -16634,7 +16622,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
 			"requires": {
 				"p-limit": "^2.2.0"
 			}
@@ -16642,8 +16629,7 @@
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"parent-module": {
 			"version": "1.0.1",
@@ -16688,8 +16674,7 @@
 		"path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -16744,7 +16729,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
 			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
 			"requires": {
 				"find-up": "^4.0.0"
 			}
@@ -17156,7 +17140,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
 			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-			"dev": true,
 			"requires": {
 				"resolve-from": "^5.0.0"
 			}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
     "fs-extra": "9.1.0",
     "immer": "8.0.1",
     "import-from": "3.0.0",
+    "import-local": "3.0.2",
     "inquirer": "7.3.3",
     "js-yaml": "4.0.0",
     "json-colorizer": "2.2.2",
@@ -24,8 +25,8 @@
     "semver": "7.3.4",
     "sha3": "2.1.4",
     "single-trailing-newline": "1.0.0",
-    "type-fest": "0.21.2",
     "tmp": "0.2.1",
+    "type-fest": "0.21.2",
     "wrap-ansi": "7.0.0"
   },
   "devDependencies": {
@@ -42,9 +43,9 @@
     "@types/semver": "7.3.4",
     "@types/single-trailing-newline": "1.0.0",
     "@types/tmp": "0.2.0",
+    "@types/wrap-ansi": "3.0.0",
     "@typescript-eslint/eslint-plugin": "4.16.1",
     "@typescript-eslint/parser": "4.16.1",
-    "@types/wrap-ansi": "3.0.0",
     "concurrently": "6.0.0",
     "cross-env": "7.0.3",
     "eslint": "7.21.0",
@@ -54,8 +55,8 @@
     "memfs": "3.2.0",
     "memory-streams": "0.1.3",
     "strip-ansi": "6.0.0",
-    "typescript": "4.2.3",
     "ts-node": "9.1.1",
+    "typescript": "4.2.3",
     "which": "2.0.2"
   },
   "engines": {

--- a/packages/cli/test/cli/use-local-cli.test.ts
+++ b/packages/cli/test/cli/use-local-cli.test.ts
@@ -1,0 +1,44 @@
+import execa from "execa";
+import { runCli } from "../utils/run-cli";
+import { prepareCliTest } from "../utils/run-cli-test";
+
+describe("coat - local cli", () => {
+  test("should use local cli version when running coat in a project where @coat/cli is installed locally", async () => {
+    const cwd = await prepareCliTest({
+      coatManifest: {
+        name: "test-project",
+        extends: "cli-e2e-tests-template",
+      },
+      packageJson: {
+        devDependencies: {
+          // There is a template which uses a mocked version of the @coat/cli
+          // in order to verify that this integration works
+          // See: https://github.com/coat-dev/cli-e2e-tests-template/tree/%40coat/e2e-test-template-cli-mock
+          "cli-e2e-tests-template":
+            "coat-dev/cli-e2e-tests-template#coat/e2e-test-template-cli-mock",
+        },
+      },
+    });
+
+    // Install dependencies
+    await execa("npm", ["install"], { cwd });
+
+    const taskInputs = [["sync"], ["setup"], ["run", "my-script"]];
+    const tasks = await Promise.all(
+      taskInputs.map(async (taskInput) => {
+        const { task } = runCli(taskInput, { cwd });
+        const taskResult = await task;
+        return {
+          taskInput,
+          taskResult,
+        };
+      })
+    );
+
+    tasks.forEach((task) => {
+      expect(task.taskResult.stdout).toEqual(
+        `[MOCK CLI] called with: ${task.taskInput.join(" ")}`
+      );
+    });
+  });
+});


### PR DESCRIPTION
Local `@coat/cli` versions that are installed in projects should be preferred over a global installed version when coat is run directly from a command line.

This is done in order to support scenarios where a template depends on an older cli version and the globally installed version contains a breaking change.

Fixes #14 [CLI] Run local version of coat cli inside coat projects