### PR TITLE
feat(cli): ✨ Validate coat manifest and templates

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9,6 +9,9 @@
 			"version": "0.0.21",
 			"license": "MIT",
 			"dependencies": {
+				"@babel/code-frame": "7.12.13",
+				"@babel/parser": "7.13.10",
+				"@babel/types": "7.13.0",
 				"ajv": "7.2.1",
 				"boxen": "5.0.0",
 				"chalk": "4.1.0",
@@ -22,6 +25,8 @@
 				"js-yaml": "4.0.0",
 				"json-colorizer": "2.2.2",
 				"json-stable-stringify": "1.0.1",
+				"json5": "2.2.0",
+				"leven": "3.1.0",
 				"lodash": "4.17.21",
 				"ora": "5.3.0",
 				"prettier": "2.2.1",
@@ -31,6 +36,7 @@
 				"single-trailing-newline": "1.0.0",
 				"tmp": "0.2.1",
 				"type-fest": "0.21.3",
+				"unquoted-property-validator": "1.1.0",
 				"wrap-ansi": "7.0.0"
 			},
 			"bin": {
@@ -41,6 +47,7 @@
 				"@babel/core": "7.13.10",
 				"@babel/preset-env": "7.13.10",
 				"@babel/preset-typescript": "7.13.0",
+				"@types/babel__code-frame": "7.0.2",
 				"@types/fs-extra": "9.0.8",
 				"@types/inquirer": "7.3.1",
 				"@types/jest": "26.0.20",
@@ -112,15 +119,14 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
 			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-			"dev": true,
 			"dependencies": {
 				"@babel/highlight": "^7.12.13"
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.13.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-			"integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+			"version": "7.13.11",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+			"integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==",
 			"dev": true
 		},
 		"node_modules/@babel/core": {
@@ -218,9 +224,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.10.tgz",
-			"integrity": "sha512-YV7r2YxdTUaw84EwNkyrRke/TJHR/UXGiyvACRqvdVJ2/syV2rQuJNnaRLSuYiop8cMRXOgseTGoJCWX0q2fFg==",
+			"version": "7.13.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz",
+			"integrity": "sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-function-name": "^7.12.13",
@@ -416,8 +422,7 @@
 		"node_modules/@babel/helper-validator-identifier": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-			"dev": true
+			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 		},
 		"node_modules/@babel/helper-validator-option": {
 			"version": "7.12.17",
@@ -452,7 +457,6 @@
 			"version": "7.13.10",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
 			"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.12.11",
 				"chalk": "^2.0.0",
@@ -463,7 +467,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -475,7 +478,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -489,7 +491,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -497,14 +498,12 @@
 		"node_modules/@babel/highlight/node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"node_modules/@babel/highlight/node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -513,7 +512,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -525,7 +523,6 @@
 			"version": "7.13.10",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
 			"integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
-			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1471,7 +1468,6 @@
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
 			"integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.12.11",
 				"lodash": "^4.17.19",
@@ -2123,10 +2119,16 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
+		"node_modules/@types/babel__code-frame": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__code-frame/-/babel__code-frame-7.0.2.tgz",
+			"integrity": "sha512-imO+jT/yjOKOAS5GQZ8SDtwiIloAGGr6OaZDKB0V5JVaSfGZLat5K5/ZRtyKW6R60XHV3RHYPTFfhYb+wDKyKg==",
+			"dev": true
+		},
 		"node_modules/@types/babel__core": {
-			"version": "7.1.12",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
-			"integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
+			"version": "7.1.13",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.13.tgz",
+			"integrity": "sha512-CC6amBNND16pTk4K3ZqKIaba6VGKAQs3gMjEY17FVd56oI/ZWt9OhS6riYiWv9s8ENbYUi7p8lgqb0QHQvUKQQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.1.0",
@@ -2251,9 +2253,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "14.14.34",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.34.tgz",
-			"integrity": "sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==",
+			"version": "14.14.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+			"integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -2269,9 +2271,9 @@
 			"dev": true
 		},
 		"node_modules/@types/prettier": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.2.tgz",
-			"integrity": "sha512-i99hy7Ki19EqVOl77WplDrvgNugHnsSjECVR/wUrzw2TJXz1zlUfT2ngGckR6xN7yFYaijsMAqPkOLx9HgUqHg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
+			"integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
@@ -3294,9 +3296,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001200",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
-			"integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
+			"version": "1.0.30001202",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
+			"integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==",
 			"dev": true
 		},
 		"node_modules/capture-exit": {
@@ -4121,9 +4123,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.687",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
-			"integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
+			"version": "1.3.690",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz",
+			"integrity": "sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -7047,8 +7049,7 @@
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"node_modules/js-yaml": {
 			"version": "4.0.0",
@@ -7242,7 +7243,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
 			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.5"
 			},
@@ -7312,7 +7312,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -9790,9 +9789,9 @@
 			}
 		},
 		"node_modules/string-length": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
-			"integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
 			"dev": true,
 			"dependencies": {
 				"char-regex": "^1.0.2",
@@ -10008,7 +10007,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -10321,6 +10319,14 @@
 			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/unquoted-property-validator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unquoted-property-validator/-/unquoted-property-validator-1.1.0.tgz",
+			"integrity": "sha512-ZWeQoYZ7HN8DCLeaowNv2GvZIXqJptKB1uUWd08ZYc1qAmJt8tXh9nck26aoYmhJtE3jCjDqdqEfUTqcJ0R7bw==",
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/unset-value": {
@@ -10753,15 +10759,14 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
 			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.12.13"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.13.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-			"integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+			"version": "7.13.11",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+			"integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==",
 			"dev": true
 		},
 		"@babel/core": {
@@ -10847,9 +10852,9 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.10.tgz",
-			"integrity": "sha512-YV7r2YxdTUaw84EwNkyrRke/TJHR/UXGiyvACRqvdVJ2/syV2rQuJNnaRLSuYiop8cMRXOgseTGoJCWX0q2fFg==",
+			"version": "7.13.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz",
+			"integrity": "sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.12.13",
@@ -11035,8 +11040,7 @@
 		"@babel/helper-validator-identifier": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-			"dev": true
+			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 		},
 		"@babel/helper-validator-option": {
 			"version": "7.12.17",
@@ -11071,7 +11075,6 @@
 			"version": "7.13.10",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
 			"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.12.11",
 				"chalk": "^2.0.0",
@@ -11082,7 +11085,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11091,7 +11093,6 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -11102,7 +11103,6 @@
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
 					"requires": {
 						"color-name": "1.1.3"
 					}
@@ -11110,20 +11110,17 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -11133,8 +11130,7 @@
 		"@babel/parser": {
 			"version": "7.13.10",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-			"integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
-			"dev": true
+			"integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.13.8",
@@ -11878,7 +11874,6 @@
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
 			"integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.12.11",
 				"lodash": "^4.17.19",
@@ -12412,10 +12407,16 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
+		"@types/babel__code-frame": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__code-frame/-/babel__code-frame-7.0.2.tgz",
+			"integrity": "sha512-imO+jT/yjOKOAS5GQZ8SDtwiIloAGGr6OaZDKB0V5JVaSfGZLat5K5/ZRtyKW6R60XHV3RHYPTFfhYb+wDKyKg==",
+			"dev": true
+		},
 		"@types/babel__core": {
-			"version": "7.1.12",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
-			"integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
+			"version": "7.1.13",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.13.tgz",
+			"integrity": "sha512-CC6amBNND16pTk4K3ZqKIaba6VGKAQs3gMjEY17FVd56oI/ZWt9OhS6riYiWv9s8ENbYUi7p8lgqb0QHQvUKQQ==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -12540,9 +12541,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.14.34",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.34.tgz",
-			"integrity": "sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==",
+			"version": "14.14.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+			"integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -12558,9 +12559,9 @@
 			"dev": true
 		},
 		"@types/prettier": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.2.tgz",
-			"integrity": "sha512-i99hy7Ki19EqVOl77WplDrvgNugHnsSjECVR/wUrzw2TJXz1zlUfT2ngGckR6xN7yFYaijsMAqPkOLx9HgUqHg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
+			"integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
 			"dev": true
 		},
 		"@types/semver": {
@@ -13302,9 +13303,9 @@
 			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001200",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
-			"integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
+			"version": "1.0.30001202",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
+			"integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -13935,9 +13936,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.687",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
-			"integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
+			"version": "1.3.690",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz",
+			"integrity": "sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww==",
 			"dev": true
 		},
 		"emittery": {
@@ -16218,8 +16219,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "4.0.0",
@@ -16379,7 +16379,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
 			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -16428,8 +16427,7 @@
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-			"dev": true
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
 		},
 		"levn": {
 			"version": "0.4.1",
@@ -18361,9 +18359,9 @@
 			"dev": true
 		},
 		"string-length": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
-			"integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
 			"dev": true,
 			"requires": {
 				"char-regex": "^1.0.2",
@@ -18526,8 +18524,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -18751,6 +18748,11 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
 			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+		},
+		"unquoted-property-validator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unquoted-property-validator/-/unquoted-property-validator-1.1.0.tgz",
+			"integrity": "sha512-ZWeQoYZ7HN8DCLeaowNv2GvZIXqJptKB1uUWd08ZYc1qAmJt8tXh9nck26aoYmhJtE3jCjDqdqEfUTqcJ0R7bw=="
 		},
 		"unset-value": {
 			"version": "1.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,7 @@
     "js-yaml": "4.0.0",
     "json-colorizer": "2.2.2",
     "json-stable-stringify": "1.0.1",
+    "json5": "2.2.0",
     "lodash": "4.17.21",
     "ora": "5.3.0",
     "prettier": "2.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,9 @@
     "coat": "bin/coat.js"
   },
   "dependencies": {
+    "@babel/code-frame": "7.12.13",
+    "@babel/parser": "7.13.10",
+    "@babel/types": "7.13.0",
     "ajv": "7.2.1",
     "boxen": "5.0.0",
     "chalk": "4.1.0",
@@ -20,6 +23,7 @@
     "json-colorizer": "2.2.2",
     "json-stable-stringify": "1.0.1",
     "json5": "2.2.0",
+    "leven": "3.1.0",
     "lodash": "4.17.21",
     "ora": "5.3.0",
     "prettier": "2.2.1",
@@ -29,6 +33,7 @@
     "single-trailing-newline": "1.0.0",
     "tmp": "0.2.1",
     "type-fest": "0.21.3",
+    "unquoted-property-validator": "1.1.0",
     "wrap-ansi": "7.0.0"
   },
   "devDependencies": {
@@ -36,6 +41,7 @@
     "@babel/core": "7.13.10",
     "@babel/preset-env": "7.13.10",
     "@babel/preset-typescript": "7.13.0",
+    "@types/babel__code-frame": "7.0.2",
     "@types/fs-extra": "9.0.8",
     "@types/inquirer": "7.3.1",
     "@types/jest": "26.0.20",

--- a/packages/cli/src/types/coat-manifest.ts
+++ b/packages/cli/src/types/coat-manifest.ts
@@ -6,7 +6,7 @@ export interface CoatManifest {
   /**
    * The name of the coat project or template
    */
-  name: string;
+  name?: string;
   /**
    * The names of the coat templates that are extended.
    *
@@ -50,7 +50,9 @@ export interface CoatManifest {
    */
 }
 
-export interface CoatManifestStrict extends Required<CoatManifest> {
+export interface CoatManifestStrict
+  extends Pick<CoatManifest, "name">,
+    Required<Omit<CoatManifest, "name">> {
   extends: Exclude<Required<CoatManifest>["extends"], string>;
   dependencies: Exclude<Required<CoatManifest["dependencies"]>, undefined>;
 }

--- a/packages/cli/src/util/gather-extended-templates.test.ts
+++ b/packages/cli/src/util/gather-extended-templates.test.ts
@@ -1,7 +1,8 @@
-import { gatherExtendedTemplates } from "./gather-extended-templates";
 import resolveFrom from "resolve-from";
-import { CoatContext } from "../types/coat-context";
 import importFrom from "import-from";
+import stripAnsi from "strip-ansi";
+import { gatherExtendedTemplates } from "./gather-extended-templates";
+import { CoatContext } from "../types/coat-context";
 import { CoatManifestStrict } from "../types/coat-manifest";
 import { getStrictCoatManifest } from "./get-strict-coat-manifest";
 import {
@@ -12,144 +13,175 @@ import {
   COAT_GLOBAL_LOCKFILE_VERSION,
   COAT_LOCAL_LOCKFILE_VERSION,
 } from "../constants";
+import { validateCoatManifest } from "../validation/coat-manifest";
+import {
+  ValidationIssue,
+  ValidationIssueType,
+} from "../validation/validation-issue";
 
-jest.mock("resolve-from").mock("import-from");
+jest
+  .mock("resolve-from")
+  .mock("import-from")
+  .mock("../validation/coat-manifest");
 
 const testCwd = "test";
 
 const resolveFromMock = (resolveFrom as unknown) as jest.Mock;
-resolveFromMock.mockImplementation(
-  (cwd, template) => `${cwd}/${template}/index.js`
-);
+const importFromMock = (importFrom as unknown) as jest.Mock;
 
 type CoatStrictTemplate = CoatManifestStrict | (() => CoatManifestStrict);
 
-const testExtendedTemplates: {
+let testExtendedTemplates: {
   [template: string]:
     | CoatStrictTemplate
     | { default: CoatStrictTemplate; __esModule: { value: true } };
-} = {
-  [`${testCwd}/template`]: getStrictCoatManifest({
-    name: "template",
-  }),
-  [`${testCwd}/template-es6`]: {
-    default: getStrictCoatManifest({
-      name: "template",
-    }),
-    __esModule: { value: true },
-  },
-  [`${testCwd}/template-fn-result`]: getStrictCoatManifest({
-    name: "template-fn",
-  }),
-  [`${testCwd}/template-fn`]: jest.fn<CoatManifestStrict, []>(
-    () =>
-      testExtendedTemplates[
-        `${testCwd}/template-fn-result`
-      ] as CoatManifestStrict
-  ),
-  // nested test templates
-  // nested-1 (obj): nested-1-A (fn), nested-1-B (obj)
-  // nested-2 (fn): nested-2-A (fn), nested-2-B (obj), nested-common-template (obj)
-  // nested-2-A (fn): nested-2-A-1 (obj), nested-2-A-2 (fn)
-  // nested-2-B (obj): nested-common-template (obj)
-  // nested-3 (obj): (no extended template)
-  [`${testCwd}/nested`]: getStrictCoatManifest({
-    name: "nested",
-    extends: [
-      "nested-1",
-      ["nested-2", { nested2: "config-value" }],
-      "nested-3",
-    ],
-  }),
-  [`${testCwd}/nested/nested-1`]: getStrictCoatManifest({
-    name: "nested-1",
-    extends: ["nested-1-A", "nested-1-B"],
-  }),
-  [`${testCwd}/nested/nested-1/nested-1-A-result`]: getStrictCoatManifest({
-    name: "nested-1-A",
-  }),
-  [`${testCwd}/nested/nested-1/nested-1-A`]: jest.fn<CoatManifestStrict, []>(
-    () =>
-      testExtendedTemplates[
-        `${testCwd}/nested/nested-1/nested-1-A-result`
-      ] as CoatManifestStrict
-  ),
-  [`${testCwd}/nested/nested-1/nested-1-B`]: getStrictCoatManifest({
-    name: "nested-1-B",
-  }),
-  [`${testCwd}/nested/nested-2-result`]: getStrictCoatManifest({
-    name: "nested-2",
-    extends: ["nested-2-A", "nested-2-B", "nested-common-template"],
-  }),
-  [`${testCwd}/nested/nested-2`]: jest.fn<CoatManifestStrict, []>(
-    () =>
-      testExtendedTemplates[
-        `${testCwd}/nested/nested-2-result`
-      ] as CoatManifestStrict
-  ),
-  [`${testCwd}/nested/nested-2/nested-2-A-result`]: getStrictCoatManifest({
-    name: "nested-2-A",
-    extends: ["nested-2-A-1", ["nested-2-A-2", { nested2A2: "config-value" }]],
-  }),
-  [`${testCwd}/nested/nested-2/nested-2-A`]: jest.fn<CoatManifestStrict, []>(
-    () =>
-      testExtendedTemplates[
-        `${testCwd}/nested/nested-2/nested-2-A-result`
-      ] as CoatManifestStrict
-  ),
-  [`${testCwd}/nested/nested-2/nested-2-A/nested-2-A-1`]: getStrictCoatManifest(
-    {
-      name: "nested-2-A-1",
-    }
-  ),
-  [`${testCwd}/nested/nested-2/nested-2-A/nested-2-A-2-result`]: getStrictCoatManifest(
-    {
-      name: "nested-2-A-2",
-    }
-  ),
-  [`${testCwd}/nested/nested-2/nested-2-A/nested-2-A-2`]: jest.fn<
-    CoatManifestStrict,
-    []
-  >(
-    () =>
-      testExtendedTemplates[
-        `${testCwd}/nested/nested-2/nested-2-A/nested-2-A-2-result`
-      ] as CoatManifestStrict
-  ),
-  [`${testCwd}/nested/nested-2/nested-2-B`]: getStrictCoatManifest({
-    name: "nested-2-B",
-    extends: ["nested-common-template"],
-  }),
-  [`${testCwd}/nested/nested-2/nested-2-B/nested-common-template`]: getStrictCoatManifest(
-    {
-      name: "nested-common-template",
-      dependencies: {
-        dependencies: {
-          "from-2-B": "^1.0.0",
-        },
-      },
-    }
-  ),
-  [`${testCwd}/nested/nested-2/nested-common-template`]: getStrictCoatManifest({
-    name: "nested-common-template",
-    dependencies: {
-      dependencies: {
-        "from-2": "^1.0.0",
-      },
-    },
-  }),
-  [`${testCwd}/nested/nested-3`]: getStrictCoatManifest({
-    name: "nested-3",
-  }),
 };
-const importFromMock = (importFrom as unknown) as jest.Mock;
-importFromMock.mockImplementation((cwd, template) => {
-  return testExtendedTemplates[`${cwd}/${template}`];
-});
+
+const validateCoatManifestMock = (validateCoatManifest as unknown) as jest.Mock;
+const consoleErrorSpy = jest.spyOn(console, "error");
 
 describe("sync/gather-extended-templates", () => {
+  beforeEach(() => {
+    resolveFromMock.mockImplementation(
+      (cwd, template) => `${cwd}/${template}/index.js`
+    );
+    importFromMock.mockImplementation((cwd, template) => {
+      return testExtendedTemplates[`${cwd}/${template}`];
+    });
+    consoleErrorSpy.mockImplementation(() => {
+      // Ignore error messages
+    });
+    validateCoatManifestMock.mockReturnValue([]);
+
+    testExtendedTemplates = {
+      [`${testCwd}/template`]: getStrictCoatManifest({
+        name: "template",
+      }),
+      [`${testCwd}/template-es6`]: {
+        default: getStrictCoatManifest({
+          name: "template",
+        }),
+        __esModule: { value: true },
+      },
+      [`${testCwd}/template-fn-result`]: getStrictCoatManifest({
+        name: "template-fn",
+      }),
+      [`${testCwd}/template-fn`]: jest.fn<CoatManifestStrict, []>(
+        () =>
+          testExtendedTemplates[
+            `${testCwd}/template-fn-result`
+          ] as CoatManifestStrict
+      ),
+      // nested test templates
+      // nested-1 (obj): nested-1-A (fn), nested-1-B (obj)
+      // nested-2 (fn): nested-2-A (fn), nested-2-B (obj), nested-common-template (obj)
+      // nested-2-A (fn): nested-2-A-1 (obj), nested-2-A-2 (fn)
+      // nested-2-B (obj): nested-common-template (obj)
+      // nested-3 (obj): (no extended template)
+      [`${testCwd}/nested`]: getStrictCoatManifest({
+        name: "nested",
+        extends: [
+          "nested-1",
+          ["nested-2", { nested2: "config-value" }],
+          "nested-3",
+        ],
+      }),
+      [`${testCwd}/nested/nested-1`]: getStrictCoatManifest({
+        name: "nested-1",
+        extends: ["nested-1-A", "nested-1-B"],
+      }),
+      [`${testCwd}/nested/nested-1/nested-1-A-result`]: getStrictCoatManifest({
+        name: "nested-1-A",
+      }),
+      [`${testCwd}/nested/nested-1/nested-1-A`]: jest.fn<
+        CoatManifestStrict,
+        []
+      >(
+        () =>
+          testExtendedTemplates[
+            `${testCwd}/nested/nested-1/nested-1-A-result`
+          ] as CoatManifestStrict
+      ),
+      [`${testCwd}/nested/nested-1/nested-1-B`]: getStrictCoatManifest({
+        name: "nested-1-B",
+      }),
+      [`${testCwd}/nested/nested-2-result`]: getStrictCoatManifest({
+        name: "nested-2",
+        extends: ["nested-2-A", "nested-2-B", "nested-common-template"],
+      }),
+      [`${testCwd}/nested/nested-2`]: jest.fn<CoatManifestStrict, []>(
+        () =>
+          testExtendedTemplates[
+            `${testCwd}/nested/nested-2-result`
+          ] as CoatManifestStrict
+      ),
+      [`${testCwd}/nested/nested-2/nested-2-A-result`]: getStrictCoatManifest({
+        name: "nested-2-A",
+        extends: [
+          "nested-2-A-1",
+          ["nested-2-A-2", { nested2A2: "config-value" }],
+        ],
+      }),
+      [`${testCwd}/nested/nested-2/nested-2-A`]: jest.fn<
+        CoatManifestStrict,
+        []
+      >(
+        () =>
+          testExtendedTemplates[
+            `${testCwd}/nested/nested-2/nested-2-A-result`
+          ] as CoatManifestStrict
+      ),
+      [`${testCwd}/nested/nested-2/nested-2-A/nested-2-A-1`]: getStrictCoatManifest(
+        {
+          name: "nested-2-A-1",
+        }
+      ),
+      [`${testCwd}/nested/nested-2/nested-2-A/nested-2-A-2-result`]: getStrictCoatManifest(
+        {
+          name: "nested-2-A-2",
+        }
+      ),
+      [`${testCwd}/nested/nested-2/nested-2-A/nested-2-A-2`]: jest.fn<
+        CoatManifestStrict,
+        []
+      >(
+        () =>
+          testExtendedTemplates[
+            `${testCwd}/nested/nested-2/nested-2-A/nested-2-A-2-result`
+          ] as CoatManifestStrict
+      ),
+      [`${testCwd}/nested/nested-2/nested-2-B`]: getStrictCoatManifest({
+        name: "nested-2-B",
+        extends: ["nested-common-template"],
+      }),
+      [`${testCwd}/nested/nested-2/nested-2-B/nested-common-template`]: getStrictCoatManifest(
+        {
+          name: "nested-common-template",
+          dependencies: {
+            dependencies: {
+              "from-2-B": "^1.0.0",
+            },
+          },
+        }
+      ),
+      [`${testCwd}/nested/nested-2/nested-common-template`]: getStrictCoatManifest(
+        {
+          name: "nested-common-template",
+          dependencies: {
+            dependencies: {
+              "from-2": "^1.0.0",
+            },
+          },
+        }
+      ),
+      [`${testCwd}/nested/nested-3`]: getStrictCoatManifest({
+        name: "nested-3",
+      }),
+    };
+  });
+
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   test("should retrieve a single extended template exporting a manifest", () => {
@@ -336,6 +368,166 @@ describe("sync/gather-extended-templates", () => {
     ).toHaveBeenCalledWith({
       coatContext,
       config: { nested2A2: "config-value" },
+    });
+  });
+
+  describe("template validation", () => {
+    test("should not log any messages if there are no validation issues", async () => {
+      const coatContext: CoatContext = {
+        cwd: testCwd,
+        coatManifest: getStrictCoatManifest({
+          name: "testManifest",
+          extends: ["template"],
+        }),
+        packageJson: {},
+        coatGlobalLockfile: getStrictCoatGlobalLockfile({
+          version: COAT_GLOBAL_LOCKFILE_VERSION,
+        }),
+        coatLocalLockfile: getStrictCoatLocalLockfile({
+          version: COAT_LOCAL_LOCKFILE_VERSION,
+        }),
+      };
+
+      gatherExtendedTemplates(coatContext);
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    test("should log warnings before errors", async () => {
+      const coatContext: CoatContext = {
+        cwd: testCwd,
+        coatManifest: getStrictCoatManifest({
+          name: "testManifest",
+          extends: ["template"],
+        }),
+        packageJson: {},
+        coatGlobalLockfile: getStrictCoatGlobalLockfile({
+          version: COAT_GLOBAL_LOCKFILE_VERSION,
+        }),
+        coatLocalLockfile: getStrictCoatLocalLockfile({
+          version: COAT_LOCAL_LOCKFILE_VERSION,
+        }),
+      };
+
+      validateCoatManifestMock.mockReturnValue([
+        {
+          type: ValidationIssueType.Error,
+          message: "an error",
+          propertyPath: ["a", "b"],
+          shortMessage: "",
+        },
+        {
+          type: ValidationIssueType.Error,
+          message: "second error",
+          propertyPath: ["a", "b", "c"],
+          shortMessage: "",
+        },
+        {
+          type: ValidationIssueType.Warning,
+          message: "a warning",
+          propertyPath: ["d"],
+        },
+      ] as ValidationIssue[]);
+
+      expect(() =>
+        gatherExtendedTemplates(coatContext)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Validation of template \\"template\\" threw errors."`
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      const errorMessage = stripAnsi(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toMatchInlineSnapshot(`
+        "The extended template \\"template\\" has the following issues:
+
+         WARNING  - a warning
+         ERROR  - an error
+         ERROR  - second error
+        "
+      `);
+    });
+
+    test("should throw if there is a validation error", async () => {
+      const coatContext: CoatContext = {
+        cwd: testCwd,
+        coatManifest: getStrictCoatManifest({
+          name: "testManifest",
+          extends: ["template"],
+        }),
+        packageJson: {},
+        coatGlobalLockfile: getStrictCoatGlobalLockfile({
+          version: COAT_GLOBAL_LOCKFILE_VERSION,
+        }),
+        coatLocalLockfile: getStrictCoatLocalLockfile({
+          version: COAT_LOCAL_LOCKFILE_VERSION,
+        }),
+      };
+
+      validateCoatManifestMock.mockReturnValue([
+        {
+          type: ValidationIssueType.Error,
+          message: "an error",
+          propertyPath: ["a", "b"],
+          shortMessage: "",
+        },
+      ] as ValidationIssue[]);
+
+      expect(() =>
+        gatherExtendedTemplates(coatContext)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Validation of template \\"template\\" threw an error."`
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      const errorMessage = stripAnsi(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toMatchInlineSnapshot(`
+        "The extended template \\"template\\" has the following issue:
+
+         ERROR  - an error
+        "
+      `);
+    });
+
+    test("should not throw an error if there are only warnings", async () => {
+      const coatContext: CoatContext = {
+        cwd: testCwd,
+        coatManifest: getStrictCoatManifest({
+          name: "testManifest",
+          extends: ["template"],
+        }),
+        packageJson: {},
+        coatGlobalLockfile: getStrictCoatGlobalLockfile({
+          version: COAT_GLOBAL_LOCKFILE_VERSION,
+        }),
+        coatLocalLockfile: getStrictCoatLocalLockfile({
+          version: COAT_LOCAL_LOCKFILE_VERSION,
+        }),
+      };
+
+      validateCoatManifestMock.mockReturnValue([
+        {
+          type: ValidationIssueType.Warning,
+          message: "a warning",
+          propertyPath: ["d"],
+        },
+        {
+          type: ValidationIssueType.Warning,
+          message: "second warning",
+          propertyPath: ["e"],
+        },
+      ] as ValidationIssue[]);
+
+      gatherExtendedTemplates(coatContext);
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      const errorMessage = stripAnsi(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toMatchInlineSnapshot(`
+        "The extended template \\"template\\" has the following issues:
+
+         WARNING  - a warning
+         WARNING  - second warning
+        "
+      `);
     });
   });
 });

--- a/packages/cli/src/util/get-context.test.ts
+++ b/packages/cli/src/util/get-context.test.ts
@@ -1,14 +1,32 @@
 import fs from "fs-extra";
 import path from "path";
 import { vol } from "memfs";
+import stripAnsi from "strip-ansi";
 import { getContext } from "./get-context";
 import { PACKAGE_JSON_FILENAME } from "../constants";
+import { validateCoatManifest } from "../validation/coat-manifest";
+import {
+  ValidationIssue,
+  ValidationIssueType,
+} from "../validation/validation-issue";
 
-jest.mock("fs");
+jest.mock("fs").mock("../validation/coat-manifest");
+
+const validateCoatManifestMock = (validateCoatManifest as unknown) as jest.Mock;
+
+const consoleErrorSpy = jest.spyOn(console, "error");
 
 describe("util/get-context", () => {
+  beforeEach(() => {
+    validateCoatManifestMock.mockReturnValue([]);
+    consoleErrorSpy.mockImplementation(() => {
+      // Empty mock function
+    });
+  });
+
   afterEach(() => {
     vol.reset();
+    jest.resetAllMocks();
   });
 
   async function createTestContextFiles(
@@ -17,7 +35,10 @@ describe("util/get-context", () => {
     packageJson: unknown
   ): Promise<void> {
     await Promise.all([
-      fs.outputFile(path.join(cwd, "coat.json"), JSON.stringify(coatManifest)),
+      fs.outputFile(
+        path.join(cwd, "coat.json"),
+        JSON.stringify(coatManifest, null, 2)
+      ),
       fs.outputFile(
         path.join(cwd, "package.json"),
         JSON.stringify(packageJson)
@@ -142,5 +163,145 @@ describe("util/get-context", () => {
       "message",
       "Unexpected token u in JSON at position 0"
     );
+  });
+
+  describe("coat manifest validation", () => {
+    test("should not log any messages if there are no validation issues", async () => {
+      const testCwd = "/test";
+      const coatManifest = {
+        name: "hi",
+      };
+      const packageJson = {
+        name: "hi",
+        version: "1.0.0",
+      };
+      await createTestContextFiles(testCwd, coatManifest, packageJson);
+      await getContext(testCwd);
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    test("should log warnings before errors", async () => {
+      const testCwd = "/test";
+      const coatManifest = {
+        name: "hi",
+      };
+      const packageJson = {
+        name: "hi",
+        version: "1.0.0",
+      };
+      await createTestContextFiles(testCwd, coatManifest, packageJson);
+
+      validateCoatManifestMock.mockReturnValue([
+        {
+          type: ValidationIssueType.Error,
+          message: "an error",
+          propertyPath: ["a", "b"],
+          shortMessage: "",
+        },
+        {
+          type: ValidationIssueType.Error,
+          message: "second error",
+          propertyPath: ["a", "b", "c"],
+          shortMessage: "",
+        },
+        {
+          type: ValidationIssueType.Warning,
+          message: "a warning",
+          propertyPath: ["d"],
+        },
+      ] as ValidationIssue[]);
+
+      await expect(() => getContext(testCwd)).rejects.toMatchInlineSnapshot(
+        `[Error: Validation of coat manifest threw errors.]`
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      const errorMessage = stripAnsi(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toMatchInlineSnapshot(`
+        "The coat manifest file (coat.json) has the following issues:
+
+         WARNING  - a warning
+         ERROR  - an error
+         ERROR  - second error
+        "
+      `);
+    });
+
+    test("should not throw an error if there are only warnings", async () => {
+      const testCwd = "/test";
+      const coatManifest = {
+        name: "hi",
+      };
+      const packageJson = {
+        name: "hi",
+        version: "1.0.0",
+      };
+      await createTestContextFiles(testCwd, coatManifest, packageJson);
+
+      validateCoatManifestMock.mockReturnValue([
+        {
+          type: ValidationIssueType.Warning,
+          message: "a warning",
+          propertyPath: ["d"],
+        },
+        {
+          type: ValidationIssueType.Warning,
+          message: "second warning",
+          propertyPath: ["e"],
+        },
+      ] as ValidationIssue[]);
+
+      await getContext(testCwd);
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      const errorMessage = stripAnsi(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toMatchInlineSnapshot(`
+        "The coat manifest file (coat.json) has the following issues:
+
+         WARNING  - a warning
+         WARNING  - second warning
+        "
+      `);
+    });
+
+    test("should show a code frame if there is only a single error", async () => {
+      const testCwd = "/test";
+      const coatManifest = {
+        name: "hi",
+      };
+      const packageJson = {
+        name: "hi",
+        version: "1.0.0",
+      };
+      await createTestContextFiles(testCwd, coatManifest, packageJson);
+
+      validateCoatManifestMock.mockReturnValue([
+        {
+          type: ValidationIssueType.Error,
+          message: "name is wrong",
+          propertyPath: ["name"],
+          shortMessage: "name is wrong",
+        },
+      ] as ValidationIssue[]);
+
+      await expect(() => getContext(testCwd)).rejects.toMatchInlineSnapshot(
+        `[Error: Validation of coat manifest threw an error.]`
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      const errorMessage = stripAnsi(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toMatchInlineSnapshot(`
+        "The coat manifest file (coat.json) has the following issue:
+
+         ERROR  - name is wrong
+
+          1 | {
+        > 2 |   \\"name\\": \\"hi\\"
+            |   ^^^^^^^^^^^^ name is wrong
+          3 | }
+        "
+      `);
+    });
   });
 });

--- a/packages/cli/src/util/get-context.ts
+++ b/packages/cli/src/util/get-context.ts
@@ -1,6 +1,10 @@
 import { promises as fs } from "fs";
 import path from "path";
+import groupBy from "lodash/groupBy";
+import chalk from "chalk";
 import json5 from "json5";
+import { parseExpression as parse } from "@babel/parser";
+import { codeFrameColumns } from "@babel/code-frame";
 import { CoatManifest } from "../types/coat-manifest";
 import { COAT_MANIFEST_FILENAME } from "../constants";
 import { getStrictCoatManifest } from "./get-strict-coat-manifest";
@@ -10,6 +14,13 @@ import {
   getCoatLocalLockfile,
 } from "../lockfiles/get-coat-lockfiles";
 import { getPackageJson } from "./get-package-json";
+import { getLocationInJSONAst } from "./get-location-in-json-ast";
+import { validateCoatManifest } from "../validation/coat-manifest";
+import {
+  ValidationIssueType,
+  ValidationIssueError,
+  ValidationIssueWarning,
+} from "../validation/validation-issue";
 
 /**
  * Retrieves and parses files that are relevant
@@ -34,6 +45,62 @@ export async function getContext(cwd: string): Promise<CoatContext> {
   ]);
 
   const coatManifest: CoatManifest = json5.parse(coatManifestRaw);
+
+  // Validation
+  const issues = [...validateCoatManifest(coatManifest)];
+  if (issues.length) {
+    const {
+      [ValidationIssueType.Error]: errors = [],
+      [ValidationIssueType.Warning]: warnings = [],
+    } = groupBy(issues, "type") as {
+      [ValidationIssueType.Error]: ValidationIssueError[];
+      [ValidationIssueType.Warning]: ValidationIssueWarning[];
+    };
+    const validationMessages = [
+      chalk`The coat manifest file ({green ${COAT_MANIFEST_FILENAME}}) has the following issue${
+        issues.length > 1 ? "s" : ""
+      }:`,
+      "",
+    ];
+
+    validationMessages.push(
+      ...warnings.map(
+        (warning) => chalk`{inverse.yellow.bold  WARNING } - ${warning.message}`
+      )
+    );
+
+    validationMessages.push(
+      ...errors.map(
+        (error) => chalk`{inverse.red.bold  ERROR } - ${error.message}`
+      )
+    );
+
+    if (issues.length === 1 && errors.length === 1) {
+      const [error] = errors;
+      const coatManifestAst = parse(coatManifestRaw);
+      const location = getLocationInJSONAst(
+        coatManifestAst,
+        error.propertyPath
+      );
+      const codeFrame = codeFrameColumns(coatManifestRaw, location, {
+        highlightCode: true,
+        message: error.shortMessage,
+      });
+      validationMessages.push("", codeFrame);
+    }
+
+    validationMessages.push("");
+    console.error(validationMessages.join("\n"));
+
+    if (errors.length) {
+      throw new Error(
+        `Validation of coat manifest threw ${
+          errors.length > 1 ? "errors" : "an error"
+        }.`
+      );
+    }
+  }
+
   const coatManifestStrict = getStrictCoatManifest(coatManifest);
 
   return {

--- a/packages/cli/src/util/get-context.ts
+++ b/packages/cli/src/util/get-context.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "fs";
 import path from "path";
+import json5 from "json5";
 import { CoatManifest } from "../types/coat-manifest";
 import { COAT_MANIFEST_FILENAME } from "../constants";
 import { getStrictCoatManifest } from "./get-strict-coat-manifest";
@@ -32,7 +33,7 @@ export async function getContext(cwd: string): Promise<CoatContext> {
     getPackageJson(cwd),
   ]);
 
-  const coatManifest: CoatManifest = JSON.parse(coatManifestRaw);
+  const coatManifest: CoatManifest = json5.parse(coatManifestRaw);
   const coatManifestStrict = getStrictCoatManifest(coatManifest);
 
   return {

--- a/packages/cli/src/util/get-location-in-json-ast.test.ts
+++ b/packages/cli/src/util/get-location-in-json-ast.test.ts
@@ -1,0 +1,205 @@
+import { parseExpression } from "@babel/parser";
+import { cloneDeepWithoutLoc } from "@babel/types";
+import { getLocationInJSONAst } from "./get-location-in-json-ast";
+
+describe("util/get-location-in-json-ast", () => {
+  test("should throw an object if root ast is not an object", () => {
+    const source = JSON.stringify(123);
+    const ast = parseExpression(source);
+
+    expect(() =>
+      getLocationInJSONAst(ast, ["any"])
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected ast root node to be ObjectExpression for current path: any"`
+    );
+  });
+
+  test("should throw error if property cannot be found", () => {
+    const source = JSON.stringify({ a: 1 });
+    const ast = parseExpression(source);
+
+    expect(() =>
+      getLocationInJSONAst(ast, ["b"])
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Could not find property for current path: b"`
+    );
+  });
+
+  test("should throw error if loc information cannot be found", () => {
+    const source = JSON.stringify({ a: 1 });
+    const ast = cloneDeepWithoutLoc(parseExpression(source));
+
+    expect(() =>
+      getLocationInJSONAst(ast, ["a"])
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Property does not have loc information for current path: a"`
+    );
+  });
+
+  test("should throw error if path expects array but finds an object", () => {
+    const source = JSON.stringify({ a: { b: true } });
+    const ast = parseExpression(source);
+
+    expect(() =>
+      getLocationInJSONAst(ast, ["a", 0])
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected ast root node to be ArrayExpression for current path: 0"`
+    );
+  });
+
+  test("should throw error if path expects an array element, but index is out of bounds", () => {
+    const source = JSON.stringify({ a: { b: [1, 2, 3] } });
+    const ast = parseExpression(source);
+
+    expect(() =>
+      getLocationInJSONAst(ast, ["a", "b", 3])
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Array element is not defined for current path: 3"`
+    );
+  });
+
+  test("should throw error if loc information of an array element cannot be found", () => {
+    const source = JSON.stringify({ a: { b: [1, 2, 3] } });
+    const ast = cloneDeepWithoutLoc(parseExpression(source));
+
+    expect(() =>
+      getLocationInJSONAst(ast, ["a", "b", 1])
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Element does not have loc information for current path: 1"`
+    );
+  });
+
+  test("should return deep property path", () => {
+    const source = JSON.stringify(
+      { a: { b: { c: [0, 1, 2, { d: true }] } } },
+      null,
+      2
+    );
+    const ast = parseExpression(source);
+
+    const location = getLocationInJSONAst(ast, ["a", "b", "c", 3, "d"]);
+
+    expect(location).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "column": 20,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 9,
+        },
+      }
+    `);
+  });
+
+  test("should return deep array element", () => {
+    const source = JSON.stringify(
+      { a: { b: { c: [0, 1, 2, { d: ["a", "b", "c"] }] } } },
+      null,
+      2
+    );
+    const ast = parseExpression(source);
+
+    const location = getLocationInJSONAst(ast, ["a", "b", "c", 3, "d", 1]);
+
+    expect(location).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "column": 16,
+          "line": 11,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 11,
+        },
+      }
+    `);
+  });
+
+  test("should return multi line location info for a larger object", () => {
+    const source = JSON.stringify(
+      { a: { b: { c: [0, 1, 2, { d: ["a", "b", "c"] }] } } },
+      null,
+      2
+    );
+    const ast = parseExpression(source);
+
+    const location = getLocationInJSONAst(ast, ["a", "b", "c"]);
+
+    expect(location).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "column": 7,
+          "line": 15,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 4,
+        },
+      }
+    `);
+  });
+
+  test("should return full AST location is property path is empty", () => {
+    const source = JSON.stringify(
+      { a: { b: { c: [0, 1, 2, { d: ["a", "b", "c"] }] } } },
+      null,
+      2
+    );
+    const ast = parseExpression(source);
+
+    const location = getLocationInJSONAst(ast, []);
+
+    expect(location).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "column": 1,
+          "line": 18,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+        },
+      }
+    `);
+  });
+
+  test("should throw an error if full AST location should be returned but loc information is missing", () => {
+    const source = JSON.stringify(
+      { a: { b: { c: [0, 1, 2, { d: ["a", "b", "c"] }] } } },
+      null,
+      2
+    );
+    const ast = cloneDeepWithoutLoc(parseExpression(source));
+
+    expect(() =>
+      getLocationInJSONAst(ast, [])
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"AST does not have loc information."`
+    );
+  });
+
+  test("should work with a non-string property identifier (JSON5)", () => {
+    const source = `{
+      a: {
+        b: 5
+      }
+    }`;
+    const ast = parseExpression(source);
+
+    const location = getLocationInJSONAst(ast, ["a", "b"]);
+    expect(location).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "column": 13,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 3,
+        },
+      }
+    `);
+  });
+});

--- a/packages/cli/src/util/get-location-in-json-ast.ts
+++ b/packages/cli/src/util/get-location-in-json-ast.ts
@@ -1,0 +1,131 @@
+import {
+  SourceLocation,
+  Expression,
+  ObjectProperty,
+  isArrayExpression,
+  isObjectExpression,
+  isObjectProperty,
+  isIdentifier,
+  isStringLiteral,
+} from "@babel/types";
+
+/**
+ * Adjusts a source location to correctly display the
+ * helper characters for @babel/codeframe in a JSON AST.
+ *
+ * @param location The source location property of the AST or node
+ * @returns The adjusted source location
+ */
+function shiftLocation(location: SourceLocation): SourceLocation {
+  const singleLine = location.start.line === location.end.line;
+
+  return {
+    start: {
+      ...location.start,
+      column: location.start.column + 1,
+    },
+    end: {
+      ...location.end,
+      column: singleLine ? location.end.column + 1 : location.end.column,
+    },
+  };
+}
+
+/**
+ * Returns the source location of a property path inside a JSON AST.
+ *
+ * @param ast The JSON AST parsed by @babel/parser
+ * @param path The property path within the JSON object
+ * @returns The source location
+ */
+export function getLocationInJSONAst(
+  ast: Expression,
+  path: (string | number)[]
+): SourceLocation {
+  const [head, ...tail] = path;
+
+  if (typeof head === "undefined") {
+    // The property path is empty, which means that the location
+    // should describe the whole JSON value
+    //
+    if (!ast.loc) {
+      throw new Error("AST does not have loc information.");
+    }
+    return shiftLocation(ast.loc);
+  } else if (typeof head === "string") {
+    if (!isObjectExpression(ast)) {
+      throw new Error(
+        `Expected ast root node to be ObjectExpression for current path: ${path.join(
+          "."
+        )}`
+      );
+    }
+
+    // Find the desired property within the AST
+    const desiredProperty = ast.properties
+      .filter((prop): prop is ObjectProperty => isObjectProperty(prop))
+      // Reverse the AST to prefer property declarations that follow later,
+      // since JSON properties can be written multiple times and the
+      // most recent declaration overwrites previous ones.
+      .reverse()
+      .find(
+        (prop) =>
+          // Typical JSON string literal, e.g.:
+          // { "a": 1 }
+          (isStringLiteral(prop.key) && prop.key.value === head) ||
+          // JSON5 non-string identifier, e.g.:
+          // { a: 1 }
+          (isIdentifier(prop.key) && prop.key.name)
+      );
+
+    if (!desiredProperty) {
+      throw new Error(
+        `Could not find property for current path: ${path.join(".")}`
+      );
+    }
+
+    if (tail.length) {
+      return getLocationInJSONAst(desiredProperty.value as Expression, tail);
+    }
+
+    if (!desiredProperty.loc) {
+      throw new Error(
+        `Property does not have loc information for current path: ${path.join(
+          "."
+        )}`
+      );
+    }
+
+    return shiftLocation(desiredProperty.loc);
+  }
+
+  if (!isArrayExpression(ast)) {
+    throw new Error(
+      `Expected ast root node to be ArrayExpression for current path: ${path.join(
+        "."
+      )}`
+    );
+  }
+
+  const element = ast.elements[head];
+
+  if (!element) {
+    throw new Error(
+      `Array element is not defined for current path: ${path.join(".")}`
+    );
+  }
+
+  if (tail.length) {
+    return getLocationInJSONAst(element as Expression, tail);
+  }
+
+  if (!element.loc) {
+    throw new Error(
+      `Element does not have loc information for current path: ${path.join(
+        "."
+      )}`
+    );
+  }
+
+  return shiftLocation(element.loc);
+}

--- a/packages/cli/src/validation/coat-manifest/index.test.ts
+++ b/packages/cli/src/validation/coat-manifest/index.test.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import chalk from "chalk";
+import { validateCoatManifest } from ".";
+import { CoatManifest } from "../../types/coat-manifest";
+import { ValidationIssueType } from "../validation-issue";
+
+describe("validation/coat-manifest - index", () => {
+  test("should return no issues for a manifest without any property", () => {
+    const testManifest: CoatManifest = {};
+
+    const issues = [...validateCoatManifest(testManifest)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test("should return an issue for an unknown property - with a suggestion", () => {
+    const testManifest: CoatManifest = {
+      // @ts-expect-error Typo to provoke suggestion
+      extendds: ["template"],
+    };
+
+    const issues = [...validateCoatManifest(testManifest)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green extendds:} Unknown property. Did you mean {magenta extends}?`,
+        propertyPath: ["extendds"],
+      },
+    ]);
+  });
+
+  test("should return an issue for an unknown property - without a suggestion", () => {
+    const testManifest: CoatManifest = {
+      // @ts-expect-error Typo to provoke suggestion
+      unknown: "unknown",
+    };
+
+    const issues = [...validateCoatManifest(testManifest)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green unknown:} Unknown property.`,
+        propertyPath: ["unknown"],
+      },
+    ]);
+  });
+
+  test.each`
+    manifest      | description
+    ${"asdfsadf"} | ${"string"}
+    ${123123}     | ${"number"}
+    ${() => {}}   | ${"function"}
+    ${true}       | ${"boolean"}
+    ${[]}         | ${"array"}
+    ${null}       | ${"null"}
+  `(
+    "should return an issue if the coat manifest is invalid - $description",
+    ({ manifest }) => {
+      const issues = [...validateCoatManifest(manifest)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: "The coat manifest file must contain a valid JSON object.",
+          propertyPath: [],
+          shortMessage:
+            "The coat manifest file must contain a valid JSON object.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    manifest      | description
+    ${"asdfsadf"} | ${"string"}
+    ${123123}     | ${"number"}
+    ${() => {}}   | ${"function"}
+    ${true}       | ${"boolean"}
+    ${[]}         | ${"array"}
+    ${null}       | ${"null"}
+  `(
+    "should return an issue if a coat template is invalid - $description",
+    ({ manifest }) => {
+      const issues = [...validateCoatManifest(manifest, { isTemplate: true })];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: "The coat template must be a valid object.",
+          propertyPath: [],
+          shortMessage: "The coat template must be a valid object.",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue if a template function returned a promise instead of a manifest", () => {
+    // @ts-expect-error Type error to provoke issue
+    const testManifest: CoatManifest = Promise.resolve({});
+
+    const issues = [
+      ...validateCoatManifest(testManifest, { isTemplate: true }),
+    ];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message:
+          "The coat template resolved to a promise. Template functions must return the template synchronously.",
+        propertyPath: [],
+        shortMessage:
+          "The coat template resolved to a promise. Template functions must return the template synchronously.",
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/validation/coat-manifest/index.ts
+++ b/packages/cli/src/validation/coat-manifest/index.ts
@@ -1,0 +1,90 @@
+import { CoatManifest } from "../../types/coat-manifest";
+import { validateCoatManifestScripts } from "./validate-coat-manifest-scripts";
+import { ValidationIssue, ValidationIssueType } from "../validation-issue";
+import { validateCoatManifestDependencies } from "./validate-coat-manifest-dependencies";
+import { validateCoatManifestExtends } from "./validate-coat-manifest-extends";
+import { validateCoatManifestFiles } from "./validate-coat-manifest-files";
+import { validateCoatManifestName } from "./validate-coat-manifest-name";
+import { validateCoatManifestSetup } from "./validate-coat-manifest-setup";
+import { handleUnknownProperties } from "../handle-unknown-properties";
+
+interface ValidationOptions {
+  isTemplate?: boolean;
+}
+
+/**
+ * Validates a coat manifest or template
+ *
+ * @param coatManifest The coat manifest or template object
+ * @param options.isTemplate Whether `coatManifest` is a template
+ * @returns A generator that returns ValidationIssues
+ */
+export function* validateCoatManifest(
+  coatManifest: CoatManifest,
+  { isTemplate }: ValidationOptions = {}
+): Generator<ValidationIssue, void, void> {
+  if (
+    typeof coatManifest !== "object" ||
+    Array.isArray(coatManifest) ||
+    coatManifest === null
+  ) {
+    const message = isTemplate
+      ? "The coat template must be a valid object."
+      : "The coat manifest file must contain a valid JSON object.";
+    yield {
+      type: ValidationIssueType.Error,
+      message,
+      propertyPath: [],
+      shortMessage: message,
+    };
+
+    return;
+  }
+
+  // Ensure that coat templates are not returning
+  // promises and run synchronously
+  if ("then" in coatManifest && typeof coatManifest["then"] === "function") {
+    // isTemplate === true is implied,
+    // since the coat manifest is a JSON file and can't be a promise.
+    const message =
+      "The coat template resolved to a promise. Template functions must return the template synchronously.";
+    yield {
+      type: ValidationIssueType.Error,
+      message,
+      propertyPath: [],
+      shortMessage: message,
+    };
+    return;
+  }
+
+  const {
+    name,
+    extends: extendsProp,
+    dependencies,
+    files,
+    scripts,
+    setup,
+    ...additionalProps
+  } = coatManifest;
+
+  yield* validateCoatManifestName(name);
+  yield* validateCoatManifestExtends(extendsProp);
+  yield* validateCoatManifestDependencies(dependencies);
+  yield* validateCoatManifestFiles(files);
+  yield* validateCoatManifestScripts(scripts);
+  yield* validateCoatManifestSetup(setup);
+
+  yield* handleUnknownProperties({
+    allOptionalProps: [
+      "name",
+      "extends",
+      "dependencies",
+      "files",
+      "scripts",
+      "setup",
+    ],
+    declaredProps: Object.keys(coatManifest),
+    unknownProps: Object.keys(additionalProps),
+    propertyPrefixPath: [],
+  });
+}

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-dependencies.test.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-dependencies.test.ts
@@ -1,0 +1,203 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import chalk from "chalk";
+import { CoatManifest } from "../../types/coat-manifest";
+import { ValidationIssueType } from "../validation-issue";
+import { validateCoatManifestDependencies } from "./validate-coat-manifest-dependencies";
+
+describe("validation/coat-manifest/validate-coat-manifest-dependencies", () => {
+  test("should return no issues for an empty object", () => {
+    const dependencies: CoatManifest["dependencies"] = {};
+
+    const issues = [...validateCoatManifestDependencies(dependencies)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test.each`
+    dependencies                                   | description
+    ${{ dependencies: {} }}                        | ${"empty dependencies"}
+    ${{ dependencies: { dep: "^1.0.0" } }}         | ${"dependencies with entries"}
+    ${{ devDependencies: {} }}                     | ${"empty devDependencies"}
+    ${{ devDependencies: { dep: "^1.0.0" } }}      | ${"devDependencies with entries"}
+    ${{ optionalDependencies: {} }}                | ${"empty optionalDependencies"}
+    ${{ optionalDependencies: { dep: "^1.0.0" } }} | ${"optionalDependencies with entries"}
+    ${{ peerDependencies: {} }}                    | ${"empty peerDependencies"}
+    ${{ peerDependencies: { dep: "^1.0.0" } }}     | ${"peerDependencies with entries"}
+  `(
+    "should return no issues for a single valid dependency property - $description",
+    ({ dependencies }) => {
+      const issues = [...validateCoatManifestDependencies(dependencies)];
+
+      expect(issues).toHaveLength(0);
+    }
+  );
+  test("should return no issues for full valid dependency properties", () => {
+    const dependencies: CoatManifest["dependencies"] = {
+      dependencies: {
+        dep: "^1.0.0",
+      },
+      devDependencies: {
+        dep2: "^1.0.0",
+      },
+      optionalDependencies: {
+        dep3: "^1.0.0",
+      },
+      peerDependencies: {
+        dep4: "^1.0.0",
+      },
+    };
+
+    const issues = [...validateCoatManifestDependencies(dependencies)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test.each`
+    dependencies  | description
+    ${"asdfsadf"} | ${"string"}
+    ${123123}     | ${"number"}
+    ${() => {}}   | ${"function"}
+    ${true}       | ${"boolean"}
+    ${[]}         | ${"array"}
+    ${null}       | ${"null"}
+  `(
+    "should return an issue for an invalid prop type - $description",
+    ({ dependencies }) => {
+      const issues = [...validateCoatManifestDependencies(dependencies)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green dependencies:} must be an object.`,
+          propertyPath: ["dependencies"],
+          shortMessage: "must be an object.",
+        },
+      ]);
+    }
+  );
+
+  test("should return a warning for unknown properties - with suggestion", () => {
+    const dependencies: CoatManifest["dependencies"] = {
+      // @ts-expect-error Typo in dependencies
+      dependenccies: {
+        dep: "^1.0.0",
+      },
+    };
+
+    const issues = [...validateCoatManifestDependencies(dependencies)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green dependencies.dependenccies:} Unknown property. Did you mean {magenta dependencies}?`,
+        propertyPath: ["dependencies", "dependenccies"],
+      },
+    ]);
+  });
+  test("should return a warning for unknown properties - without suggestion", () => {
+    const dependencies: CoatManifest["dependencies"] = {
+      // @ts-expect-error Unknown property
+      somethingElse: {
+        dep: "^1.0.0",
+      },
+    };
+
+    const issues = [...validateCoatManifestDependencies(dependencies)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green dependencies.somethingElse:} Unknown property.`,
+        propertyPath: ["dependencies", "somethingElse"],
+      },
+    ]);
+  });
+
+  const dependencyTypes = [
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+  ];
+  for (const dependencyType of dependencyTypes) {
+    describe(dependencyType, () => {
+      test.each`
+        deps          | description
+        ${"asdfsadf"} | ${"string"}
+        ${123123}     | ${"number"}
+        ${() => {}}   | ${"function"}
+        ${true}       | ${"boolean"}
+        ${[]}         | ${"array"}
+        ${null}       | ${"null"}
+      `(
+        `should return an issue if ${dependencyType} is not an object - $description`,
+        ({ deps }) => {
+          const dependencies: CoatManifest["dependencies"] = {
+            [dependencyType]: deps,
+          };
+
+          const issues = [...validateCoatManifestDependencies(dependencies)];
+
+          expect(issues).toHaveLength(1);
+          expect(issues).toEqual([
+            {
+              type: ValidationIssueType.Error,
+              message: chalk`{green dependencies.${dependencyType}:} must be an object.`,
+              propertyPath: ["dependencies", dependencyType],
+              shortMessage: "must be an object.",
+            },
+          ]);
+        }
+      );
+    });
+
+    test("should return an issue for an empty dependency name", () => {
+      const dependencies: CoatManifest["dependencies"] = {
+        [dependencyType]: {
+          "": "^1.0.0",
+        },
+      };
+
+      const issues = [...validateCoatManifestDependencies(dependencies)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green dependencies.${dependencyType}:} must not contain an empty dependency name.`,
+          propertyPath: ["dependencies", dependencyType],
+          shortMessage: "must not contain an empty dependency name.",
+        },
+      ]);
+    });
+
+    test("should return an issue for empty dependency versions", () => {
+      const dependencies: CoatManifest["dependencies"] = {
+        [dependencyType]: {
+          a: "",
+          b: "^1.0.0",
+          "@scoped/dependency": "",
+        },
+      };
+
+      const issues = [...validateCoatManifestDependencies(dependencies)];
+
+      expect(issues).toHaveLength(2);
+      expect(issues).toContainEqual({
+        type: ValidationIssueType.Error,
+        message: chalk`{green dependencies.${dependencyType}.a:} dependency version must not be empty.`,
+        propertyPath: ["dependencies", dependencyType, "a"],
+        shortMessage: "dependency version must not be empty.",
+      });
+      expect(issues).toContainEqual({
+        type: ValidationIssueType.Error,
+        message: chalk`{green dependencies.${dependencyType}['@scoped/dependency']:} dependency version must not be empty.`,
+        propertyPath: ["dependencies", dependencyType, "@scoped/dependency"],
+        shortMessage: "dependency version must not be empty.",
+      });
+    });
+  }
+});

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-dependencies.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-dependencies.ts
@@ -1,0 +1,104 @@
+import isPlainObject from "lodash/isPlainObject";
+import { CoatManifest } from "../../types/coat-manifest";
+import { formatPropertyPath } from "../format-property-path";
+import { handleUnknownProperties } from "../handle-unknown-properties";
+import { ValidationIssue, ValidationIssueType } from "../validation-issue";
+
+function* validateDependenciesType(
+  dependencies: Record<string, string> | undefined,
+  propertyName: string
+): Generator<ValidationIssue, void, void> {
+  if (typeof dependencies === "undefined") {
+    return;
+  }
+  const propertyPath = ["dependencies", propertyName];
+  const messagePrefix = formatPropertyPath(propertyPath);
+
+  if (!isPlainObject(dependencies)) {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${messagePrefix} must be an object.`,
+      propertyPath,
+      shortMessage: "must be an object.",
+    };
+  } else {
+    const dependencyEntries = Object.entries(dependencies);
+
+    for (const [dependencyKey, dependencyVersion] of dependencyEntries) {
+      // Should not contain any empty key
+      if (dependencyKey === "") {
+        yield {
+          type: ValidationIssueType.Error,
+          message: `${messagePrefix} must not contain an empty dependency name.`,
+          propertyPath,
+          shortMessage: "must not contain an empty dependency name.",
+        };
+      }
+
+      if (typeof dependencyVersion !== "string" || !dependencyVersion) {
+        // Should not contain an empty version for a dependency
+        yield {
+          type: ValidationIssueType.Error,
+          message: `${formatPropertyPath([
+            "dependencies",
+            propertyName,
+            dependencyKey,
+          ])} dependency version must not be empty.`,
+          propertyPath: [...propertyPath, dependencyKey],
+          shortMessage: "dependency version must not be empty.",
+        };
+      }
+    }
+  }
+}
+
+export function* validateCoatManifestDependencies(
+  dependenciesProp: CoatManifest["dependencies"]
+): Generator<ValidationIssue, void, void> {
+  if (typeof dependenciesProp !== "undefined") {
+    if (
+      typeof dependenciesProp !== "object" ||
+      Array.isArray(dependenciesProp) ||
+      dependenciesProp === null
+    ) {
+      yield {
+        type: ValidationIssueType.Error,
+        message: `${formatPropertyPath(["dependencies"])} must be an object.`,
+        propertyPath: ["dependencies"],
+        shortMessage: "must be an object.",
+      };
+      return;
+    }
+
+    const {
+      dependencies,
+      devDependencies,
+      optionalDependencies,
+      peerDependencies,
+      ...additionalDependenciesProps
+    } = dependenciesProp;
+
+    yield* validateDependenciesType(dependencies, "dependencies");
+    yield* validateDependenciesType(devDependencies, "devDependencies");
+    yield* validateDependenciesType(
+      optionalDependencies,
+      "optionalDependencies"
+    );
+    yield* validateDependenciesType(peerDependencies, "peerDependencies");
+
+    const additionalDependenciesPropsKeys = Object.keys(
+      additionalDependenciesProps
+    );
+    yield* handleUnknownProperties({
+      unknownProps: additionalDependenciesPropsKeys,
+      declaredProps: Object.keys(dependenciesProp),
+      allOptionalProps: [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies",
+      ],
+      propertyPrefixPath: ["dependencies"],
+    });
+  }
+}

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-extends.test.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-extends.test.ts
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import chalk from "chalk";
+import { CoatManifest } from "../../types/coat-manifest";
+import { ValidationIssueType } from "../validation-issue";
+import { validateCoatManifestExtends } from "./validate-coat-manifest-extends";
+
+describe("validation/coat-manifest/validate-coat-manifest-extends", () => {
+  test("should return no issues for a valid string", () => {
+    const extendsProp: CoatManifest["extends"] = "my-template";
+
+    const issues = [...validateCoatManifestExtends(extendsProp)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test("should return no issues for an empty array", () => {
+    const extendsProp: CoatManifest["extends"] = [];
+
+    const issues = [...validateCoatManifestExtends(extendsProp)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test("should return no issues for a valid array", () => {
+    const extendsProp: CoatManifest["extends"] = [
+      "my-template",
+      ["my-second-tempalte", { configValue: true }],
+    ];
+
+    const issues = [...validateCoatManifestExtends(extendsProp)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test.each`
+    entry       | description
+    ${123}      | ${"number"}
+    ${{}}       | ${"object"}
+    ${true}     | ${"boolean"}
+    ${() => {}} | ${"function"}
+    ${null}     | ${"null"}
+  `(
+    "should return an issue for an invalid extends property - $description",
+    ({ entry }) => {
+      const extendsProp: CoatManifest["extends"] = entry;
+
+      const issues = [...validateCoatManifestExtends(extendsProp)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green extends:} must either be a template name or an array of templates.`,
+          propertyPath: ["extends"],
+          shortMessage:
+            "must either be a template name or an array of templates.",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for an empty string", () => {
+    const extendsProp: CoatManifest["extends"] = "";
+
+    const issues = [...validateCoatManifestExtends(extendsProp)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message: chalk`{green extends:} template name must not be empty.`,
+        propertyPath: ["extends"],
+        shortMessage: "template name must not be empty.",
+      },
+    ]);
+  });
+
+  test.each`
+    template    | description
+    ${123}      | ${"number"}
+    ${{}}       | ${"object"}
+    ${true}     | ${"boolean"}
+    ${() => {}} | ${"function"}
+    ${null}     | ${"null"}
+  `(
+    "should return an issue for an invalid member in the array - $description",
+    ({ template }) => {
+      const extendsProp: CoatManifest["extends"] = ["my-template", template];
+
+      const issues = [...validateCoatManifestExtends(extendsProp)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green extends[1]:} array entries must either be a template name or tuple ([templateName, \{ templateConfig: true \}]).`,
+          propertyPath: ["extends", 1],
+          shortMessage:
+            "must either be a template name or a tuple ([templateName, { templateConfig: true }]).",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for an empty string member in the array", () => {
+    const extendsProp: CoatManifest["extends"] = ["my-template", ""];
+
+    const issues = [...validateCoatManifestExtends(extendsProp)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message: chalk`{green extends[1]:} template name must not be empty.`,
+        propertyPath: ["extends", 1],
+        shortMessage: "template name must not be empty.",
+      },
+    ]);
+  });
+
+  test.each`
+    template                                                 | description
+    ${[]}                                                    | ${"array length: 0"}
+    ${["my-template"]}                                       | ${"array length: 1"}
+    ${["my-template", { config1: true }, { config2: true }]} | ${"array length: 3"}
+  `(
+    "should return an issue for tuples that are not couples - $description",
+    ({ template }) => {
+      const extendsProp: CoatManifest["extends"] = ["my-template", template];
+
+      const issues = [...validateCoatManifestExtends(extendsProp)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green extends[1]:} tuple entries must be couples (e.g. [templateName, \{ templateConfig: true \}]).`,
+          propertyPath: ["extends", 1],
+          shortMessage:
+            "must be a couple (e.g. [templateName, { templateConfig: true }]).",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    template          | description
+    ${[123, {}]}      | ${"number"}
+    ${[{}, {}]}       | ${"object"}
+    ${[true, {}]}     | ${"boolean"}
+    ${[[], {}]}       | ${"array"}
+    ${[() => {}, {}]} | ${"function"}
+    ${["", {}]}       | ${"empty string"}
+    ${[null, {}]}     | ${"null"}
+  `(
+    "should return an issue for tuples that have an invalid template name value - $description",
+    ({ template }) => {
+      const extendsProp: CoatManifest["extends"] = ["my-template", template];
+
+      const issues = [...validateCoatManifestExtends(extendsProp)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green extends[1]:} tuple entries must have a template name as the first member.`,
+          propertyPath: ["extends", 1, 0],
+          shortMessage: "must be a template name.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    template                     | description
+    ${["my-template", 123]}      | ${"number"}
+    ${["my-template", true]}     | ${"boolean"}
+    ${["my-template", []]}       | ${"array"}
+    ${["my-template", () => {}]} | ${"function"}
+    ${["my-template", "config"]} | ${"string"}
+    ${["my-template", null]}     | ${"null"}
+  `(
+    "should return an issue for tuples that have an invalid template config value - $description",
+    ({ template }) => {
+      const extendsProp: CoatManifest["extends"] = ["my-template", template];
+
+      const issues = [...validateCoatManifestExtends(extendsProp)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green extends[1]:} tuple entries must have a configuration object as the second member.`,
+          propertyPath: ["extends", 1, 1],
+          shortMessage: "must be a configuration object",
+        },
+      ]);
+    }
+  );
+});

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-extends.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-extends.ts
@@ -1,0 +1,101 @@
+import { CoatManifest } from "../../types/coat-manifest";
+import { formatPropertyPath } from "../format-property-path";
+import { ValidationIssue, ValidationIssueType } from "../validation-issue";
+
+export function* validateCoatManifestExtends(
+  extendsProp: CoatManifest["extends"]
+): Generator<ValidationIssue, void, void> {
+  if (typeof extendsProp !== "undefined") {
+    if (typeof extendsProp !== "string" && !Array.isArray(extendsProp)) {
+      yield {
+        type: ValidationIssueType.Error,
+        message: `${formatPropertyPath([
+          "extends",
+        ])} must either be a template name or an array of templates.`,
+        propertyPath: ["extends"],
+        shortMessage:
+          "must either be a template name or an array of templates.",
+      };
+    }
+
+    // should not be empty if it is a string
+    if (typeof extendsProp === "string" && !extendsProp) {
+      yield {
+        type: ValidationIssueType.Error,
+        message: `${formatPropertyPath([
+          "extends",
+        ])} template name must not be empty.`,
+        propertyPath: ["extends"],
+        shortMessage: "template name must not be empty.",
+      };
+    } else if (Array.isArray(extendsProp)) {
+      for (const [index, extendsEntry] of extendsProp.entries()) {
+        // should either be a non-empty string or a tuple
+        if (typeof extendsEntry !== "string" && !Array.isArray(extendsEntry)) {
+          yield {
+            type: ValidationIssueType.Error,
+            message: `${formatPropertyPath([
+              "extends",
+              index,
+            ])} array entries must either be a template name or tuple ([templateName, { templateConfig: true }]).`,
+            propertyPath: ["extends", index],
+            shortMessage:
+              "must either be a template name or a tuple ([templateName, { templateConfig: true }]).",
+          };
+        } else if (typeof extendsEntry === "string") {
+          if (!extendsEntry) {
+            yield {
+              type: ValidationIssueType.Error,
+              message: `${formatPropertyPath([
+                "extends",
+                index,
+              ])} template name must not be empty.`,
+              propertyPath: ["extends", index],
+              shortMessage: "template name must not be empty.",
+            };
+          }
+        } else {
+          if (extendsEntry.length !== 2) {
+            yield {
+              type: ValidationIssueType.Error,
+              message: `${formatPropertyPath([
+                "extends",
+                index,
+              ])} tuple entries must be couples (e.g. [templateName, { templateConfig: true }]).`,
+              propertyPath: ["extends", index],
+              shortMessage:
+                "must be a couple (e.g. [templateName, { templateConfig: true }]).",
+            };
+          } else {
+            if (typeof extendsEntry[0] !== "string" || !extendsEntry[0]) {
+              yield {
+                type: ValidationIssueType.Error,
+                message: `${formatPropertyPath([
+                  "extends",
+                  index,
+                ])} tuple entries must have a template name as the first member.`,
+                propertyPath: ["extends", index, 0],
+                shortMessage: "must be a template name.",
+              };
+            }
+            if (
+              typeof extendsEntry[1] !== "object" ||
+              Array.isArray(extendsEntry[1]) ||
+              extendsEntry[1] === null
+            ) {
+              yield {
+                type: ValidationIssueType.Error,
+                message: `${formatPropertyPath([
+                  "extends",
+                  index,
+                ])} tuple entries must have a configuration object as the second member.`,
+                propertyPath: ["extends", index, 1],
+                shortMessage: "must be a configuration object",
+              };
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-files.test.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-files.test.ts
@@ -1,0 +1,523 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import chalk from "chalk";
+import {
+  CoatManifestFile,
+  CoatManifestFileType,
+} from "../../types/coat-manifest-file";
+import { ValidationIssueType } from "../validation-issue";
+import { validateCoatManifestFiles } from "./validate-coat-manifest-files";
+
+describe("validation/coat-manifest/validate-coat-manifest-files", () => {
+  test("should return no issues for an empty files array", () => {
+    const files: CoatManifestFile[] = [];
+
+    const issues = [...validateCoatManifestFiles(files)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test("should return no issues for valid files", () => {
+    const files: CoatManifestFile[] = [
+      {
+        type: CoatManifestFileType.Json,
+        file: "file1.json",
+        content: {
+          a: true,
+        },
+      },
+      {
+        type: CoatManifestFileType.Yaml,
+        file: "file2.yaml",
+        content: {
+          b: true,
+        },
+        local: true,
+      },
+      {
+        type: CoatManifestFileType.Text,
+        file: "file3.txt",
+        content: async () => "some-text",
+        local: true,
+        once: true,
+      },
+    ];
+
+    const issues = [...validateCoatManifestFiles(files)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test.each`
+    files       | description
+    ${123}      | ${"number"}
+    ${{}}       | ${"object"}
+    ${"string"} | ${"string"}
+    ${true}     | ${"boolean"}
+    ${() => {}} | ${"function"}
+    ${null}     | ${"null"}
+  `(
+    "should return an issue if files are not an array - $description",
+    ({ files }) => {
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green files:} must be an array.`,
+          propertyPath: ["files"],
+          shortMessage: "must be an array.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    files         | description
+    ${[123]}      | ${"number"}
+    ${["file"]}   | ${"string"}
+    ${[[]]}       | ${"array"}
+    ${[true]}     | ${"boolean"}
+    ${[() => {}]} | ${"function"}
+    ${[null]}     | ${"null"}
+  `(
+    "should return an issue for an invalid files array entry - $description",
+    ({ files }) => {
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green files[0]:} must be an object.`,
+          propertyPath: ["files", 0],
+          shortMessage: "must be an object.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    files                                                  | description
+    ${[{ file: 123, type: "TEXT", content: "text" }]}      | ${"number"}
+    ${[{ file: [], type: "TEXT", content: "text" }]}       | ${"array"}
+    ${[{ file: [], type: "TEXT", content: "text" }]}       | ${"object"}
+    ${[{ file: true, type: "TEXT", content: "text" }]}     | ${"boolean"}
+    ${[{ file: () => {}, type: "TEXT", content: "text" }]} | ${"function"}
+    ${[{ file: null, type: "TEXT", content: "text" }]}     | ${"null"}
+    ${[{ file: "", type: "TEXT", content: "text" }]}       | ${"empty string"}
+  `(
+    "should return an issue for an invalid file property - $description",
+    ({ files }) => {
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green files[0].file:} must be a relative path.`,
+          propertyPath: ["files", 0, "file"],
+          shortMessage: "must be a relative path.",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for a missing file property - with a suggestion", () => {
+    const files: CoatManifestFile[] = [
+      {
+        type: CoatManifestFileType.Text,
+        content: "test",
+        // @ts-expect-error Typo to provoke suggestion
+        fille: "file.txt",
+      },
+    ];
+
+    const issues = [...validateCoatManifestFiles(files)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message: chalk`{green files[0].file:} must be a relative path. Did you misspell {magenta fille}?`,
+        propertyPath: ["files", 0, "fille"],
+        shortMessage: chalk`did you mean to write {magenta file}?`,
+      },
+    ]);
+  });
+
+  test("should return an issue for a missing file property - without a suggestion", () => {
+    const files: CoatManifestFile[] = [
+      {
+        type: CoatManifestFileType.Text,
+        content: "test",
+        // @ts-expect-error Additional property for test
+        anotherDifferentProperty: "file.txt",
+      },
+    ];
+
+    const issues = [...validateCoatManifestFiles(files)];
+
+    expect(issues).toHaveLength(2);
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Error,
+      message: chalk`{green files[0]:} must have a {magenta file} property with the relative file path.`,
+      propertyPath: ["files", 0],
+      shortMessage: chalk`must have a {magenta file} property with a relative path.`,
+    });
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Warning,
+      message: chalk`{green files[0].anotherDifferentProperty:} Unknown property.`,
+      propertyPath: ["files", 0, "anotherDifferentProperty"],
+    });
+  });
+
+  test.each`
+    files                                                   | description
+    ${[{ file: "file", type: 123, content: "text" }]}       | ${"number"}
+    ${[{ file: "file", type: [], content: "text" }]}        | ${"array"}
+    ${[{ file: "file", type: {}, content: "text" }]}        | ${"object"}
+    ${[{ file: "file", type: true, content: "text" }]}      | ${"boolean"}
+    ${[{ file: "file", type: () => {}, content: "text" }]}  | ${"function"}
+    ${[{ file: "file", type: null, content: "text" }]}      | ${"null"}
+    ${[{ file: "file", type: "", content: "text" }]}        | ${"empty string"}
+    ${[{ file: "file", type: "UNKNOWN", content: "text" }]} | ${"unknown type"}
+  `(
+    "should return an issue for an invalid type property - $description",
+    ({ files }) => {
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green files[0].type:} must be either {green "JSON"}, {green "YAML"} or {green "TEXT"}.`,
+          propertyPath: ["files", 0, "type"],
+          shortMessage: chalk`must be either {green "JSON"}, {green "YAML"} or {green "TEXT"}.`,
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for a missing type property - with a suggestion", () => {
+    const files: CoatManifestFile[] = [
+      {
+        file: "file",
+        content: "test",
+        // @ts-expect-error Typo to provoke suggestion
+        typpe: "TEXT",
+      },
+    ];
+
+    const issues = [...validateCoatManifestFiles(files)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message: chalk`{green files[0].type:} must be either {green "JSON"}, {green "YAML"} or {green "TEXT"}. Did you misspell {magenta typpe}?`,
+        propertyPath: ["files", 0, "typpe"],
+        shortMessage: chalk`did you mean to write {magenta type}?`,
+      },
+    ]);
+  });
+
+  test("should return an issue for a missing type property - without a suggestion", () => {
+    const files: CoatManifestFile[] = [
+      {
+        file: "file",
+        content: "test",
+        // @ts-expect-error Additional unknown property
+        else: "TEXT",
+      },
+    ];
+
+    const issues = [...validateCoatManifestFiles(files)];
+
+    expect(issues).toHaveLength(2);
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Error,
+      message: chalk`{green files[0]:} must have a {magenta type} property that is either {green "JSON"}, {green "YAML"} or {green "TEXT"}.`,
+      propertyPath: ["files", 0],
+      shortMessage: chalk`must have a {magenta type} property that is either {green "JSON"}, {green "YAML"} or {green "TEXT"}.`,
+    });
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Warning,
+      message: chalk`{green files[0].else:} Unknown property.`,
+      propertyPath: ["files", 0, "else"],
+    });
+  });
+
+  test.each`
+    files                                                                | description
+    ${[{ file: "file", type: "TEXT", content: "text", once: 123 }]}      | ${"number"}
+    ${[{ file: "file", type: "TEXT", content: "text", once: [] }]}       | ${"array"}
+    ${[{ file: "file", type: "TEXT", content: "text", once: {} }]}       | ${"object"}
+    ${[{ file: "file", type: "TEXT", content: "text", once: () => {} }]} | ${"function"}
+    ${[{ file: "file", type: "TEXT", content: "text", once: null }]}     | ${"null"}
+  `(
+    "should return an issue for an invalid once property - $description",
+    ({ files }) => {
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green files[0].once:} must be a boolean.`,
+          propertyPath: ["files", 0, "once"],
+          shortMessage: "must be a boolean.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    files                                                                 | description
+    ${[{ file: "file", type: "TEXT", content: "text", local: 123 }]}      | ${"number"}
+    ${[{ file: "file", type: "TEXT", content: "text", local: [] }]}       | ${"array"}
+    ${[{ file: "file", type: "TEXT", content: "text", local: {} }]}       | ${"object"}
+    ${[{ file: "file", type: "TEXT", content: "text", local: () => {} }]} | ${"function"}
+    ${[{ file: "file", type: "TEXT", content: "text", local: null }]}     | ${"null"}
+  `(
+    "should return an issue for an invalid once property - $description",
+    ({ files }) => {
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green files[0].local:} must be a boolean.`,
+          propertyPath: ["files", 0, "local"],
+          shortMessage: "must be a boolean.",
+        },
+      ]);
+    }
+  );
+
+  describe("JSON", () => {
+    test.each`
+      files                                                | description
+      ${[{ file: "file", type: "JSON", content: 123 }]}    | ${"number"}
+      ${[{ file: "file", type: "JSON", content: [] }]}     | ${"array"}
+      ${[{ file: "file", type: "JSON", content: true }]}   | ${"boolean"}
+      ${[{ file: "file", type: "JSON", content: "text" }]} | ${"string"}
+    `(
+      "should return an issue for an invalid content property - $description",
+      ({ files }) => {
+        const issues = [...validateCoatManifestFiles(files)];
+
+        expect(issues).toHaveLength(1);
+        expect(issues).toEqual([
+          {
+            type: ValidationIssueType.Error,
+            message: chalk`{green files[0].content:} must be null, a valid JSON object or a function that returns one, since the file.type is JSON.`,
+            propertyPath: ["files", 0, "content"],
+            shortMessage:
+              "must be null, a valid JSON object or a function that returns one.",
+          },
+        ]);
+      }
+    );
+
+    test("should return an issue for a missing content property - with a suggestion", () => {
+      const files: CoatManifestFile[] = [
+        {
+          file: "file",
+          type: CoatManifestFileType.Json,
+          // @ts-expect-error Typo to provoke suggestion
+          conttent: {},
+        },
+      ];
+
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green files[0].content:} must be null, a valid JSON object or a function that returns one, since the file.type is JSON. Did you misspell {magenta conttent}?`,
+          propertyPath: ["files", 0, "conttent"],
+          shortMessage: chalk`did you mean to write {magenta content}?`,
+        },
+      ]);
+    });
+
+    test("should return an issue for a missing content property - without a suggestion", () => {
+      const files: CoatManifestFile[] = [
+        {
+          file: "file",
+          type: CoatManifestFileType.Json,
+          // @ts-expect-error Unknown property
+          else: {},
+        },
+      ];
+
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(2);
+      expect(issues).toContainEqual({
+        type: ValidationIssueType.Error,
+        message: chalk`{green files[0]:} must have a {magenta content} property that is null, a valid JSON object or a function that returns one, since the file.type is JSON.`,
+        propertyPath: ["files", 0],
+        shortMessage: chalk`must have a {magenta content} property that is null, a valid JSON object or a function that returns one.`,
+      });
+      expect(issues).toContainEqual({
+        type: ValidationIssueType.Warning,
+        message: chalk`{green files[0].else:} Unknown property.`,
+        propertyPath: ["files", 0, "else"],
+      });
+    });
+  });
+
+  describe("YAML", () => {
+    test.each`
+      files                                                | description
+      ${[{ file: "file", type: "YAML", content: 123 }]}    | ${"number"}
+      ${[{ file: "file", type: "YAML", content: [] }]}     | ${"array"}
+      ${[{ file: "file", type: "YAML", content: true }]}   | ${"boolean"}
+      ${[{ file: "file", type: "YAML", content: "text" }]} | ${"string"}
+    `(
+      "should return an issue for an invalid content property - $description",
+      ({ files }) => {
+        const issues = [...validateCoatManifestFiles(files)];
+
+        expect(issues).toHaveLength(1);
+        expect(issues).toEqual([
+          {
+            type: ValidationIssueType.Error,
+            message: chalk`{green files[0].content:} must be null, a valid JSON object or a function that returns one, since the file.type is YAML.`,
+            propertyPath: ["files", 0, "content"],
+            shortMessage:
+              "must be null, a valid JSON object or a function that returns one.",
+          },
+        ]);
+      }
+    );
+
+    test("should return an issue for a missing content property - with a suggestion", () => {
+      const files: CoatManifestFile[] = [
+        {
+          file: "file",
+          type: CoatManifestFileType.Yaml,
+          // @ts-expect-error Typo to provoke suggestion
+          conttent: {},
+        },
+      ];
+
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green files[0].content:} must be null, a valid JSON object or a function that returns one, since the file.type is YAML. Did you misspell {magenta conttent}?`,
+          propertyPath: ["files", 0, "conttent"],
+          shortMessage: chalk`did you mean to write {magenta content}?`,
+        },
+      ]);
+    });
+
+    test("should return an issue for a missing content property - without a suggestion", () => {
+      const files: CoatManifestFile[] = [
+        {
+          file: "file",
+          type: CoatManifestFileType.Yaml,
+          // @ts-expect-error Unknown property
+          else: {},
+        },
+      ];
+
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(2);
+      expect(issues).toContainEqual({
+        type: ValidationIssueType.Error,
+        message: chalk`{green files[0]:} must have a {magenta content} property that is null, a valid JSON object or a function that returns one, since the file.type is YAML.`,
+        propertyPath: ["files", 0],
+        shortMessage: chalk`must have a {magenta content} property that is null, a valid JSON object or a function that returns one.`,
+      });
+      expect(issues).toContainEqual({
+        type: ValidationIssueType.Warning,
+        message: chalk`{green files[0].else:} Unknown property.`,
+        propertyPath: ["files", 0, "else"],
+      });
+    });
+  });
+
+  describe("TEXT", () => {
+    test.each`
+      files                                              | description
+      ${[{ file: "file", type: "TEXT", content: 123 }]}  | ${"number"}
+      ${[{ file: "file", type: "TEXT", content: [] }]}   | ${"array"}
+      ${[{ file: "file", type: "TEXT", content: true }]} | ${"boolean"}
+      ${[{ file: "file", type: "TEXT", content: {} }]}   | ${"object"}
+    `(
+      "should return an issue for an invalid content property - $description",
+      ({ files }) => {
+        const issues = [...validateCoatManifestFiles(files)];
+
+        expect(issues).toHaveLength(1);
+        expect(issues).toEqual([
+          {
+            type: ValidationIssueType.Error,
+            message: chalk`{green files[0].content:} must be null, a string or a function that returns one, since the file.type is TEXT.`,
+            propertyPath: ["files", 0, "content"],
+            shortMessage:
+              "must be null, a string or a function that returns one.",
+          },
+        ]);
+      }
+    );
+
+    test("should return an issue for a missing content property - with a suggestion", () => {
+      const files: CoatManifestFile[] = [
+        {
+          file: "file",
+          type: CoatManifestFileType.Text,
+          // @ts-expect-error Typo to provoke suggestion
+          conttent: "",
+        },
+      ];
+
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green files[0].content:} must be null, a string or a function that returns one, since the file.type is TEXT. Did you misspell {magenta conttent}?`,
+          propertyPath: ["files", 0, "conttent"],
+          shortMessage: chalk`did you mean to write {magenta content}?`,
+        },
+      ]);
+    });
+
+    test("should return an issue for a missing content property - without a suggestion", () => {
+      const files: CoatManifestFile[] = [
+        {
+          file: "file",
+          type: CoatManifestFileType.Text,
+          // @ts-expect-error Unknown property
+          else: {},
+        },
+      ];
+
+      const issues = [...validateCoatManifestFiles(files)];
+
+      expect(issues).toHaveLength(2);
+      expect(issues).toContainEqual({
+        type: ValidationIssueType.Error,
+        message: chalk`{green files[0]:} must have a {magenta content} property that is null, a string or a function that returns one, since the file.type is TEXT.`,
+        propertyPath: ["files", 0],
+        shortMessage: chalk`must have a {magenta content} property that is null, a string or a function that returns one.`,
+      });
+      expect(issues).toContainEqual({
+        type: ValidationIssueType.Warning,
+        message: chalk`{green files[0].else:} Unknown property.`,
+        propertyPath: ["files", 0, "else"],
+      });
+    });
+  });
+});

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-files.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-files.ts
@@ -1,0 +1,282 @@
+import chalk from "chalk";
+import {
+  CoatManifestFile,
+  CoatManifestFileType,
+} from "../../types/coat-manifest-file";
+import { CoatManifest } from "../../types/coat-manifest";
+import { ValidationIssue, ValidationIssueType } from "../validation-issue";
+import { findPotentialPropertyMatch } from "../find-potential-property-match";
+import { handleUnknownProperties } from "../handle-unknown-properties";
+import { formatPropertyPath } from "../format-property-path";
+
+/**
+ * Dummy function to create an exhaustive switch statement that
+ * raises a compile time error when a new file type is added
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function exhaustiveTypeHelper(_type: never): void {
+  // Empty function
+}
+
+function* validateCoatManifestFile(
+  fileEntry: CoatManifestFile,
+  index: number
+): Generator<ValidationIssue, void, void> {
+  if (
+    typeof fileEntry !== "object" ||
+    fileEntry === null ||
+    Array.isArray(fileEntry)
+  ) {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath(["files", index])} must be an object.`,
+      propertyPath: ["files", index],
+      shortMessage: "must be an object.",
+    };
+    return;
+  }
+
+  const { file, content, type, local, once, ...additionalProps } = fileEntry;
+
+  const additionalPropKeys = new Set(Object.keys(additionalProps));
+
+  if (typeof file !== "string" || !file.length) {
+    if (typeof file === "undefined") {
+      const potentialPropertyMatch = findPotentialPropertyMatch("file", [
+        ...additionalPropKeys,
+      ]);
+      if (potentialPropertyMatch) {
+        additionalPropKeys.delete(potentialPropertyMatch);
+        yield {
+          type: ValidationIssueType.Error,
+          message: chalk`${formatPropertyPath([
+            "files",
+            index,
+            "file",
+          ])} must be a relative path. Did you misspell {magenta ${potentialPropertyMatch}}?`,
+          propertyPath: ["files", index, potentialPropertyMatch],
+          shortMessage: chalk`did you mean to write {magenta file}?`,
+        };
+      } else {
+        yield {
+          type: ValidationIssueType.Error,
+          message: chalk`${formatPropertyPath([
+            "files",
+            index,
+          ])} must have a {magenta file} property with the relative file path.`,
+          propertyPath: ["files", index],
+          shortMessage: chalk`must have a {magenta file} property with a relative path.`,
+        };
+      }
+    } else {
+      yield {
+        type: ValidationIssueType.Error,
+        message: `${formatPropertyPath([
+          "files",
+          index,
+          "file",
+        ])} must be a relative path.`,
+        propertyPath: ["files", index, "file"],
+        shortMessage: "must be a relative path.",
+      };
+    }
+  }
+
+  switch (type) {
+    case CoatManifestFileType.Json:
+    case CoatManifestFileType.Yaml:
+      if (
+        (content !== null &&
+          typeof content !== "object" &&
+          typeof content !== "function") ||
+        Array.isArray(content)
+      ) {
+        if (typeof content === "undefined") {
+          const potentialPropertyMatch = findPotentialPropertyMatch("content", [
+            ...additionalPropKeys,
+          ]);
+          if (potentialPropertyMatch) {
+            additionalPropKeys.delete(potentialPropertyMatch);
+            yield {
+              type: ValidationIssueType.Error,
+              message: chalk`${formatPropertyPath([
+                "files",
+                index,
+                "content",
+              ])} must be null, a valid JSON object or a function that returns one, since the file.type is ${type}. Did you misspell {magenta ${potentialPropertyMatch}}?`,
+              propertyPath: ["files", index, potentialPropertyMatch],
+              shortMessage: chalk`did you mean to write {magenta content}?`,
+            };
+          } else {
+            yield {
+              type: ValidationIssueType.Error,
+              message: chalk`${formatPropertyPath([
+                "files",
+                index,
+              ])} must have a {magenta content} property that is null, a valid JSON object or a function that returns one, since the file.type is ${type}.`,
+              propertyPath: ["files", index],
+              shortMessage: chalk`must have a {magenta content} property that is null, a valid JSON object or a function that returns one.`,
+            };
+          }
+        } else {
+          yield {
+            type: ValidationIssueType.Error,
+            message: `${formatPropertyPath([
+              "files",
+              index,
+              "content",
+            ])} must be null, a valid JSON object or a function that returns one, since the file.type is ${type}.`,
+            propertyPath: ["files", index, "content"],
+            shortMessage:
+              "must be null, a valid JSON object or a function that returns one.",
+          };
+        }
+      }
+      break;
+    case CoatManifestFileType.Text:
+      if (
+        content !== null &&
+        typeof content !== "string" &&
+        typeof content !== "function"
+      ) {
+        if (typeof content === "undefined") {
+          const potentialPropertyMatch = findPotentialPropertyMatch("content", [
+            ...additionalPropKeys,
+          ]);
+          if (potentialPropertyMatch) {
+            additionalPropKeys.delete(potentialPropertyMatch);
+            yield {
+              type: ValidationIssueType.Error,
+              message: chalk`${formatPropertyPath([
+                "files",
+                index,
+                "content",
+              ])} must be null, a string or a function that returns one, since the file.type is TEXT. Did you misspell {magenta ${potentialPropertyMatch}}?`,
+              propertyPath: ["files", index, potentialPropertyMatch],
+              shortMessage: chalk`did you mean to write {magenta content}?`,
+            };
+          } else {
+            yield {
+              type: ValidationIssueType.Error,
+              message: chalk`${formatPropertyPath([
+                "files",
+                index,
+              ])} must have a {magenta content} property that is null, a string or a function that returns one, since the file.type is TEXT.`,
+              propertyPath: ["files", index],
+              shortMessage: chalk`must have a {magenta content} property that is null, a string or a function that returns one.`,
+            };
+          }
+        } else {
+          yield {
+            type: ValidationIssueType.Error,
+            message: `${formatPropertyPath([
+              "files",
+              index,
+              "content",
+            ])} must be null, a string or a function that returns one, since the file.type is TEXT.`,
+            propertyPath: ["files", index, "content"],
+            shortMessage:
+              "must be null, a string or a function that returns one.",
+          };
+        }
+      }
+      break;
+    default:
+      exhaustiveTypeHelper(type);
+      if (typeof type === "undefined") {
+        const potentialPropertyMatch = findPotentialPropertyMatch("type", [
+          ...additionalPropKeys,
+        ]);
+        if (potentialPropertyMatch) {
+          additionalPropKeys.delete(potentialPropertyMatch);
+          yield {
+            type: ValidationIssueType.Error,
+            message: chalk`${formatPropertyPath([
+              "files",
+              index,
+              "type",
+            ])} must be either {green "JSON"}, {green "YAML"} or {green "TEXT"}. Did you misspell {magenta ${potentialPropertyMatch}}?`,
+            propertyPath: ["files", index, potentialPropertyMatch],
+            shortMessage: chalk`did you mean to write {magenta type}?`,
+          };
+        } else {
+          yield {
+            type: ValidationIssueType.Error,
+            message: chalk`${formatPropertyPath([
+              "files",
+              index,
+            ])} must have a {magenta type} property that is either {green "JSON"}, {green "YAML"} or {green "TEXT"}.`,
+            propertyPath: ["files", index],
+            shortMessage: chalk`must have a {magenta type} property that is either {green "JSON"}, {green "YAML"} or {green "TEXT"}.`,
+          };
+        }
+      } else {
+        yield {
+          type: ValidationIssueType.Error,
+          // NOTE: Update when new file types are added!
+          message: chalk`${formatPropertyPath([
+            "files",
+            index,
+            "type",
+          ])} must be either {green "JSON"}, {green "YAML"} or {green "TEXT"}.`,
+          propertyPath: ["files", index, "type"],
+          shortMessage: chalk`must be either {green "JSON"}, {green "YAML"} or {green "TEXT"}.`,
+        };
+      }
+  }
+
+  if (typeof once !== "undefined" && typeof once !== "boolean") {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath([
+        "files",
+        index,
+        "once",
+      ])} must be a boolean.`,
+      propertyPath: ["files", index, "once"],
+      shortMessage: "must be a boolean.",
+    };
+  }
+
+  if (typeof local !== "undefined" && typeof local !== "boolean") {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath([
+        "files",
+        index,
+        "local",
+      ])} must be a boolean.`,
+      propertyPath: ["files", index, "local"],
+      shortMessage: "must be a boolean.",
+    };
+  }
+
+  yield* handleUnknownProperties({
+    allOptionalProps: ["local", "once"],
+    declaredProps: Object.keys(fileEntry),
+    unknownProps: [...additionalPropKeys],
+    propertyPrefixPath: ["files", index],
+  });
+}
+
+export function* validateCoatManifestFiles(
+  files: CoatManifest["files"]
+): Generator<ValidationIssue, void, void> {
+  if (typeof files === "undefined") {
+    return;
+  }
+
+  if (!Array.isArray(files)) {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath(["files"])} must be an array.`,
+      propertyPath: ["files"],
+      shortMessage: "must be an array.",
+    };
+    return;
+  }
+
+  for (const [index, file] of files.entries()) {
+    yield* validateCoatManifestFile(file, index);
+  }
+}

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-name.test.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-name.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import chalk from "chalk";
+import { validateCoatManifest } from ".";
+import { CoatManifest } from "../../types/coat-manifest";
+import { ValidationIssueType } from "../validation-issue";
+
+describe("validation/coat-manifest/validate-coat-manifest-name", () => {
+  test("should return no issues for a valid name", () => {
+    const testManifest: CoatManifest = { name: "my-project" };
+
+    const issues = [...validateCoatManifest(testManifest)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test("should return no issues for an empty name string", () => {
+    const testManifest: CoatManifest = { name: "" };
+
+    const issues = [...validateCoatManifest(testManifest)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test.each`
+    name        | description
+    ${123}      | ${"number"}
+    ${[]}       | ${"array"}
+    ${{}}       | ${"object"}
+    ${true}     | ${"boolean"}
+    ${() => {}} | ${"function"}
+    ${null}     | ${"null"}
+  `(
+    "should return an issue for an invalid name property - $description",
+    ({ name }) => {
+      const testManifest: CoatManifest = {
+        name,
+      };
+
+      const issues = [...validateCoatManifest(testManifest)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toEqual({
+        type: ValidationIssueType.Error,
+        message: chalk`{green name:} must be a string.`,
+        propertyPath: ["name"],
+        shortMessage: "must be a string.",
+      });
+    }
+  );
+});

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-name.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-name.ts
@@ -1,0 +1,18 @@
+import { CoatManifest } from "../../types/coat-manifest";
+import { formatPropertyPath } from "../format-property-path";
+import { ValidationIssue, ValidationIssueType } from "../validation-issue";
+
+export function* validateCoatManifestName(
+  name: CoatManifest["name"]
+): Generator<ValidationIssue, void, void> {
+  // name should either be missing or a string
+  const validNameTypes = ["undefined", "string"];
+  if (!validNameTypes.includes(typeof name)) {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath(["name"])} must be a string.`,
+      propertyPath: ["name"],
+      shortMessage: "must be a string.",
+    };
+  }
+}

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-scripts.test.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-scripts.test.ts
@@ -1,0 +1,314 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import chalk from "chalk";
+import { CoatManifestScript } from "../../types/coat-manifest-script";
+import { ValidationIssueType } from "../validation-issue";
+import { validateCoatManifestScripts } from "./validate-coat-manifest-scripts";
+
+describe("validation/coat-manifest/validate-coat-manifest-name", () => {
+  test("should return no issues for an empty scripts array", () => {
+    const scripts: CoatManifestScript[] = [];
+
+    const issues = [...validateCoatManifestScripts(scripts)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test("should return no issues for valid scripts", () => {
+    const scripts: CoatManifestScript[] = [
+      {
+        id: "1",
+        run: "test-run",
+        scriptName: "test-script",
+      },
+      {
+        id: "2",
+        run: "test-run-2",
+        scriptName: "test-script-5",
+      },
+      {
+        id: "3",
+        run: "test-run-3",
+        scriptName: "test-script",
+      },
+    ];
+
+    const issues = [...validateCoatManifestScripts(scripts)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test.each`
+    scripts     | description
+    ${123}      | ${"number"}
+    ${true}     | ${"boolean"}
+    ${{}}       | ${"object"}
+    ${() => {}} | ${"function"}
+    ${"script"} | ${"string"}
+    ${null}     | ${"null"}
+  `(
+    "should return an issue for an invalid scripts property - $description",
+    ({ scripts }) => {
+      const issues = [...validateCoatManifestScripts(scripts)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green scripts:} must be an array.`,
+          propertyPath: ["scripts"],
+          shortMessage: "must be an array.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    scripts       | description
+    ${[123]}      | ${"number"}
+    ${[true]}     | ${"boolean"}
+    ${[[]]}       | ${"array"}
+    ${[() => {}]} | ${"function"}
+    ${["script"]} | ${"string"}
+    ${[null]}     | ${"null"}
+  `(
+    "should return an issue for an invalid scripts entry - $description",
+    ({ scripts }) => {
+      const issues = [...validateCoatManifestScripts(scripts)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green scripts[0]:} must be an object.`,
+          propertyPath: ["scripts", 0],
+          shortMessage: "must be an object.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    scripts                                                           | description
+    ${[{ id: 123, run: "test-run", scriptName: "test-script" }]}      | ${"number"}
+    ${[{ id: true, run: "test-run", scriptName: "test-script" }]}     | ${"boolean"}
+    ${[{ id: [], run: "test-run", scriptName: "test-script" }]}       | ${"array"}
+    ${[{ id: {}, run: "test-run", scriptName: "test-script" }]}       | ${"object"}
+    ${[{ id: () => {}, run: "test-run", scriptName: "test-script" }]} | ${"function"}
+    ${[{ id: null, run: "test-run", scriptName: "test-script" }]}     | ${"null"}
+    ${[{ id: "", run: "test-run", scriptName: "test-script" }]}       | ${"empty string"}
+  `(
+    "should return an issue for an invalid id property - $description",
+    ({ scripts }) => {
+      const issues = [...validateCoatManifestScripts(scripts)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green scripts[0].id:} must be a non-empty string.`,
+          propertyPath: ["scripts", 0, "id"],
+          shortMessage: "must be a non-empty string.",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for a missing id property - with a suggestion", () => {
+    const scripts: CoatManifestScript[] = [
+      {
+        run: "test-run",
+        scriptName: "test-script",
+        // @ts-expect-error Typo to provoke suggestion
+        ID: "test-id",
+      },
+    ];
+
+    const issues = [...validateCoatManifestScripts(scripts)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message: chalk`{green scripts[0].id:} must be a non-empty string. Did you misspell {magenta ID}?`,
+        propertyPath: ["scripts", 0, "ID"],
+        shortMessage: chalk`did you mean to write {magenta id}?`,
+      },
+    ]);
+  });
+
+  test("should return an issue for a missing id property - without a suggestion", () => {
+    const scripts: CoatManifestScript[] = [
+      {
+        run: "test-run",
+        scriptName: "test-script",
+        // @ts-expect-error To provoke unknown property
+        else: "test-id",
+      },
+    ];
+
+    const issues = [...validateCoatManifestScripts(scripts)];
+
+    expect(issues).toHaveLength(2);
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Error,
+      message: chalk`{green scripts[0]:} must have a {magenta id} property with a non-empty string.`,
+      propertyPath: ["scripts", 0],
+      shortMessage: chalk`must have a {magenta id} property with a non-empty string.`,
+    });
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Warning,
+      message: chalk`{green scripts[0].else:} Unknown property.`,
+      propertyPath: ["scripts", 0, "else"],
+    });
+  });
+
+  test.each`
+    scripts                                                     | description
+    ${[{ id: "id", run: 123, scriptName: "test-script" }]}      | ${"number"}
+    ${[{ id: "id", run: true, scriptName: "test-script" }]}     | ${"boolean"}
+    ${[{ id: "id", run: [], scriptName: "test-script" }]}       | ${"array"}
+    ${[{ id: "id", run: {}, scriptName: "test-script" }]}       | ${"object"}
+    ${[{ id: "id", run: () => {}, scriptName: "test-script" }]} | ${"function"}
+    ${[{ id: "id", run: null, scriptName: "test-script" }]}     | ${"null"}
+    ${[{ id: "id", run: "", scriptName: "test-script" }]}       | ${"empty string"}
+  `(
+    "should return an issue for an invalid run property - $description",
+    ({ scripts }) => {
+      const issues = [...validateCoatManifestScripts(scripts)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green scripts[0].run:} must be a non-empty string.`,
+          propertyPath: ["scripts", 0, "run"],
+          shortMessage: "must be a non-empty string.",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for a missing run property - with a suggestion", () => {
+    const scripts: CoatManifestScript[] = [
+      {
+        id: "test-id",
+        scriptName: "test-script",
+        // @ts-expect-error Typo to provoke suggestion
+        runn: "test-run",
+      },
+    ];
+
+    const issues = [...validateCoatManifestScripts(scripts)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message: chalk`{green scripts[0].run:} must be a non-empty string. Did you misspell {magenta runn}?`,
+        propertyPath: ["scripts", 0, "runn"],
+        shortMessage: chalk`did you mean to write {magenta run}?`,
+      },
+    ]);
+  });
+
+  test("should return an issue for a missing run property - without a suggestion", () => {
+    const scripts: CoatManifestScript[] = [
+      {
+        id: "test-id",
+        scriptName: "test-script",
+        // @ts-expect-error To provoke unknown property
+        else: "test-run",
+      },
+    ];
+
+    const issues = [...validateCoatManifestScripts(scripts)];
+
+    expect(issues).toHaveLength(2);
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Error,
+      message: chalk`{green scripts[0]:} must have a {magenta run} property with a non-empty string.`,
+      propertyPath: ["scripts", 0],
+      shortMessage: chalk`must have a {magenta run} property with a non-empty string.`,
+    });
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Warning,
+      message: chalk`{green scripts[0].else:} Unknown property.`,
+      propertyPath: ["scripts", 0, "else"],
+    });
+  });
+
+  test.each`
+    scripts                                                  | description
+    ${[{ id: "id", run: "test-run", scriptName: 123 }]}      | ${"number"}
+    ${[{ id: "id", run: "test-run", scriptName: true }]}     | ${"boolean"}
+    ${[{ id: "id", run: "test-run", scriptName: [] }]}       | ${"array"}
+    ${[{ id: "id", run: "test-run", scriptName: {} }]}       | ${"object"}
+    ${[{ id: "id", run: "test-run", scriptName: () => {} }]} | ${"function"}
+    ${[{ id: "id", run: "test-run", scriptName: null }]}     | ${"null"}
+    ${[{ id: "id", run: "test-run", scriptName: "" }]}       | ${"empty string"}
+  `(
+    "should return an issue for an invalid scriptName property",
+    ({ scripts }) => {
+      const issues = [...validateCoatManifestScripts(scripts)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green scripts[0].scriptName:} must be a non-empty string.`,
+          propertyPath: ["scripts", 0, "scriptName"],
+          shortMessage: "must be a non-empty string.",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for a missing scriptName property - with a suggestion", () => {
+    const scripts: CoatManifestScript[] = [
+      {
+        id: "test-id",
+        run: "test-run",
+        // @ts-expect-error Typo to provoke suggestion
+        scriptname: "test-script",
+      },
+    ];
+
+    const issues = [...validateCoatManifestScripts(scripts)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message: chalk`{green scripts[0].scriptName:} must be a non-empty string. Did you misspell {magenta scriptname}?`,
+        propertyPath: ["scripts", 0, "scriptname"],
+        shortMessage: chalk`did you mean to write {magenta scriptName}?`,
+      },
+    ]);
+  });
+
+  test("should return an issue for a missing scriptName property - without a suggestion", () => {
+    const scripts: CoatManifestScript[] = [
+      {
+        id: "test-id",
+        run: "test-run",
+        // @ts-expect-error To provoke unknown property
+        else: "test-script",
+      },
+    ];
+
+    const issues = [...validateCoatManifestScripts(scripts)];
+
+    expect(issues).toHaveLength(2);
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Error,
+      message: chalk`{green scripts[0]:} must have a {magenta scriptName} property with a non-empty string.`,
+      propertyPath: ["scripts", 0],
+      shortMessage: chalk`must have a {magenta scriptName} property with a non-empty string.`,
+    });
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Warning,
+      message: chalk`{green scripts[0].else:} Unknown property.`,
+      propertyPath: ["scripts", 0, "else"],
+    });
+  });
+});

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-scripts.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-scripts.ts
@@ -1,0 +1,118 @@
+import chalk from "chalk";
+import { CoatManifest } from "../../types/coat-manifest";
+import { CoatManifestScript } from "../../types/coat-manifest-script";
+import { findPotentialPropertyMatch } from "../find-potential-property-match";
+import { formatPropertyPath } from "../format-property-path";
+import { handleUnknownProperties } from "../handle-unknown-properties";
+import { ValidationIssue, ValidationIssueType } from "../validation-issue";
+
+function* validateCoatManifestScript(
+  script: CoatManifestScript,
+  index: number
+): Generator<ValidationIssue, void, void> {
+  if (typeof script !== "object" || Array.isArray(script) || script === null) {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath(["scripts", index])} must be an object.`,
+      propertyPath: ["scripts", index],
+      shortMessage: "must be an object.",
+    };
+    return;
+  }
+
+  const { id, run, scriptName, ...additionalProps } = script;
+
+  const additionalPropKeys = new Set(Object.keys(additionalProps));
+
+  const valuesToValidate = [
+    {
+      value: id,
+      prop: "id",
+    },
+    {
+      value: run,
+      prop: "run",
+    },
+    {
+      value: scriptName,
+      prop: "scriptName",
+    },
+  ];
+
+  for (const valueToValidate of valuesToValidate) {
+    if (typeof valueToValidate.value === "undefined") {
+      const potentialPropertyMatch = findPotentialPropertyMatch(
+        valueToValidate.prop,
+        [...additionalPropKeys]
+      );
+      if (potentialPropertyMatch) {
+        additionalPropKeys.delete(potentialPropertyMatch);
+        yield {
+          type: ValidationIssueType.Error,
+          message: chalk`${formatPropertyPath([
+            "scripts",
+            index,
+            valueToValidate.prop,
+          ])} must be a non-empty string. Did you misspell {magenta ${potentialPropertyMatch}}?`,
+          propertyPath: ["scripts", index, potentialPropertyMatch],
+          shortMessage: chalk`did you mean to write {magenta ${valueToValidate.prop}}?`,
+        };
+      } else {
+        yield {
+          type: ValidationIssueType.Error,
+          message: chalk`${formatPropertyPath([
+            "scripts",
+            index,
+          ])} must have a {magenta ${
+            valueToValidate.prop
+          }} property with a non-empty string.`,
+          propertyPath: ["scripts", index],
+          shortMessage: chalk`must have a {magenta ${valueToValidate.prop}} property with a non-empty string.`,
+        };
+      }
+    } else if (
+      typeof valueToValidate.value !== "string" ||
+      !valueToValidate.value
+    ) {
+      yield {
+        type: ValidationIssueType.Error,
+        message: `${formatPropertyPath([
+          "scripts",
+          index,
+          valueToValidate.prop,
+        ])} must be a non-empty string.`,
+        propertyPath: ["scripts", index, valueToValidate.prop],
+        shortMessage: "must be a non-empty string.",
+      };
+    }
+  }
+
+  yield* handleUnknownProperties({
+    allOptionalProps: [],
+    declaredProps: Object.keys(script),
+    unknownProps: [...additionalPropKeys],
+    propertyPrefixPath: ["scripts", index],
+  });
+}
+
+export function* validateCoatManifestScripts(
+  scripts: CoatManifest["scripts"]
+): Generator<ValidationIssue, void, void> {
+  if (typeof scripts === "undefined") {
+    return;
+  }
+
+  if (!Array.isArray(scripts)) {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath(["scripts"])} must be an array.`,
+      propertyPath: ["scripts"],
+      shortMessage: "must be an array.",
+    };
+    return;
+  }
+
+  for (const [index, script] of scripts.entries()) {
+    yield* validateCoatManifestScript(script, index);
+  }
+}

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-setup.test.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-setup.test.ts
@@ -1,0 +1,446 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import chalk from "chalk";
+import { CoatManifestTask } from "../../types/coat-manifest-tasks";
+import { ValidationIssueType } from "../validation-issue";
+import { validateCoatManifestSetup } from "./validate-coat-manifest-setup";
+
+describe("validation/coat-manifest/validate-coat-manifest-name", () => {
+  test("should return no issues for an empty setup array", () => {
+    const setup: CoatManifestTask[] = [];
+
+    const issues = [...validateCoatManifestSetup(setup)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test("should not return any issues for valid tasks", () => {
+    const setup: CoatManifestTask[] = [
+      {
+        id: "task1",
+        run: async () => ({}),
+      },
+      {
+        id: "task2",
+        run: () => ({}),
+        shouldRun: () => false,
+        local: false,
+      },
+      {
+        id: "task3",
+        run: () => ({}),
+        local: true,
+        runOnCi: true,
+      },
+    ];
+
+    const issues = [...validateCoatManifestSetup(setup)];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test.each`
+    setup       | description
+    ${123}      | ${"number"}
+    ${true}     | ${"boolean"}
+    ${{}}       | ${"object"}
+    ${() => {}} | ${"function"}
+    ${"setup"}  | ${"string"}
+    ${null}     | ${"null"}
+  `(
+    "should return an issue for an invalid setup property - $description",
+    ({ setup }) => {
+      const issues = [...validateCoatManifestSetup(setup)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green setup:} must be an array.`,
+          propertyPath: ["setup"],
+          shortMessage: "must be an array.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    setup         | description
+    ${[123]}      | ${"number"}
+    ${[true]}     | ${"boolean"}
+    ${[[]]}       | ${"array"}
+    ${[() => {}]} | ${"function"}
+    ${["task"]}   | ${"string"}
+    ${[null]}     | ${"null"}
+  `(
+    "should return an issue for an invalid task entry - $description",
+    ({ setup }) => {
+      const issues = [...validateCoatManifestSetup(setup)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green setup[0]:} must be an object.`,
+          propertyPath: ["setup", 0],
+          shortMessage: "must be an object.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    setup                                | description
+    ${[{ id: 123, run: () => {} }]}      | ${"number"}
+    ${[{ id: true, run: () => {} }]}     | ${"boolean"}
+    ${[{ id: [], run: () => {} }]}       | ${"array"}
+    ${[{ id: {}, run: () => {} }]}       | ${"object"}
+    ${[{ id: () => {}, run: () => {} }]} | ${"function"}
+    ${[{ id: null, run: () => {} }]}     | ${"null"}
+    ${[{ id: "", run: () => {} }]}       | ${"empty string"}
+  `(
+    "should return an issue for an invalid task id - $description",
+    ({ setup }) => {
+      const issues = [...validateCoatManifestSetup(setup)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green setup[0].id:} must be a non-empty string.`,
+          propertyPath: ["setup", 0, "id"],
+          shortMessage: "must be a non-empty string.",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for a missing task id - with a suggestion", () => {
+    const setup: CoatManifestTask[] = [
+      {
+        run: () => {},
+        // @ts-expect-error Typo to provoke suggestion
+        ID: "test-id",
+      },
+    ];
+
+    const issues = [...validateCoatManifestSetup(setup)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message: chalk`{green setup[0].id:} must be a non-empty string. Did you misspell {magenta ID}?`,
+        propertyPath: ["setup", 0, "ID"],
+        shortMessage: chalk`did you mean to write {magenta id}?`,
+      },
+    ]);
+  });
+
+  test("should return an issue for a missing task id - without a suggestion", () => {
+    const setup: CoatManifestTask[] = [
+      {
+        run: () => {},
+        // @ts-expect-error Unknown property
+        else: "test-id",
+      },
+    ];
+
+    const issues = [...validateCoatManifestSetup(setup)];
+
+    expect(issues).toHaveLength(2);
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Error,
+      message: chalk`{green setup[0]:} must have a {magenta id} property with a non-empty string.`,
+      propertyPath: ["setup", 0],
+      shortMessage: chalk`must have a {magenta id} property with a non-empty string.`,
+    });
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Warning,
+      message: chalk`{green setup[0].else:} Unknown property.`,
+      propertyPath: ["setup", 0, "else"],
+    });
+  });
+
+  test.each`
+    setup                         | description
+    ${[{ id: "id", run: 123 }]}   | ${"number"}
+    ${[{ id: "id", run: true }]}  | ${"boolean"}
+    ${[{ id: "id", run: [] }]}    | ${"array"}
+    ${[{ id: "id", run: {} }]}    | ${"object"}
+    ${[{ id: "id", run: null }]}  | ${"null"}
+    ${[{ id: "id", run: "run" }]} | ${"string"}
+  `(
+    "should return an issue for an invalid run property - $description",
+    ({ setup }) => {
+      const issues = [...validateCoatManifestSetup(setup)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green setup[0].run:} must be a function.`,
+          propertyPath: ["setup", 0, "run"],
+          shortMessage: "must be a function.",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for a missing task run function - with a suggestion", () => {
+    const setup: CoatManifestTask[] = [
+      {
+        id: "test-id",
+        // @ts-expect-error Typo to provoke suggestion
+        Run: () => {},
+      },
+    ];
+
+    const issues = [...validateCoatManifestSetup(setup)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Error,
+        message: chalk`{green setup[0].run:} must be a function. Did you misspell {magenta Run}?`,
+        propertyPath: ["setup", 0, "Run"],
+        shortMessage: chalk`did you mean to write {magenta run}?`,
+      },
+    ]);
+  });
+
+  test("should return an issue for a missing task run function - without a suggestion", () => {
+    const setup: CoatManifestTask[] = [
+      {
+        id: "test-id",
+        // @ts-expect-error Unknown property
+        else: () => {},
+      },
+    ];
+
+    const issues = [...validateCoatManifestSetup(setup)];
+
+    expect(issues).toHaveLength(2);
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Error,
+      message: chalk`{green setup[0]:} must have a {magenta run} property with a function.`,
+      propertyPath: ["setup", 0],
+      shortMessage: chalk`must have a {magenta run} property with a function.`,
+    });
+    expect(issues).toContainEqual({
+      type: ValidationIssueType.Warning,
+      message: chalk`{green setup[0].else:} Unknown property.`,
+      propertyPath: ["setup", 0, "else"],
+    });
+  });
+
+  test.each`
+    setup                                             | description
+    ${[{ id: "id", run: () => {}, local: 123 }]}      | ${"number"}
+    ${[{ id: "id", run: () => {}, local: [] }]}       | ${"array"}
+    ${[{ id: "id", run: () => {}, local: () => {} }]} | ${"function"}
+    ${[{ id: "id", run: () => {}, local: {} }]}       | ${"object"}
+    ${[{ id: "id", run: () => {}, local: null }]}     | ${"null"}
+    ${[{ id: "id", run: () => {}, local: "local" }]}  | ${"string"}
+  `(
+    "should return an issue for an invalid local property - $description",
+    ({ setup }) => {
+      const issues = [...validateCoatManifestSetup(setup)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green setup[0].local:} must be a boolean.`,
+          propertyPath: ["setup", 0, "local"],
+          shortMessage: "must be a boolean.",
+        },
+      ]);
+    }
+  );
+
+  test.each`
+    setup                                                    | description
+    ${[{ id: "id", run: () => {}, shouldRun: 123 }]}         | ${"number"}
+    ${[{ id: "id", run: () => {}, shouldRun: [] }]}          | ${"array"}
+    ${[{ id: "id", run: () => {}, shouldRun: true }]}        | ${"boolean"}
+    ${[{ id: "id", run: () => {}, shouldRun: {} }]}          | ${"object"}
+    ${[{ id: "id", run: () => {}, shouldRun: null }]}        | ${"null"}
+    ${[{ id: "id", run: () => {}, shouldRun: "shouldRun" }]} | ${"string"}
+  `(
+    "should return an issue for an invalid shouldRun property - $description",
+    ({ setup }) => {
+      const issues = [...validateCoatManifestSetup(setup)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Error,
+          message: chalk`{green setup[0].shouldRun:} must be a function.`,
+          propertyPath: ["setup", 0, "shouldRun"],
+          shortMessage: "must be a function.",
+        },
+      ]);
+    }
+  );
+
+  test("should return an issue for an unknown property - with a suggestion for local", () => {
+    const setup: CoatManifestTask[] = [
+      {
+        id: "test-id",
+        run: () => {},
+        // @ts-expect-error Typo to provoke suggestion
+        locall: true,
+      },
+    ];
+
+    const issues = [...validateCoatManifestSetup(setup)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green setup[0].locall:} Unknown property. Did you mean {magenta local}?`,
+        propertyPath: ["setup", 0, "locall"],
+      },
+    ]);
+  });
+
+  test("should return an issue for an unknown property - with a suggestion for shouldRun", () => {
+    const setup: CoatManifestTask[] = [
+      {
+        id: "test-id",
+        run: () => {},
+        // @ts-expect-error Typo to provoke suggestion
+        shouldrun: () => true,
+      },
+    ];
+
+    const issues = [...validateCoatManifestSetup(setup)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green setup[0].shouldrun:} Unknown property. Did you mean {magenta shouldRun}?`,
+        propertyPath: ["setup", 0, "shouldrun"],
+      },
+    ]);
+  });
+
+  test("should return an issue for an unknown property - without a suggestion", () => {
+    const setup: CoatManifestTask[] = [
+      {
+        id: "test-id",
+        run: () => {},
+        // @ts-expect-error Unknown property
+        else: "else",
+      },
+    ];
+
+    const issues = [...validateCoatManifestSetup(setup)];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green setup[0].else:} Unknown property.`,
+        propertyPath: ["setup", 0, "else"],
+      },
+    ]);
+  });
+
+  describe("local tasks", () => {
+    test.each`
+      setup                                                            | description
+      ${[{ id: "id", run: () => {}, local: true, runOnCi: 123 }]}      | ${"number"}
+      ${[{ id: "id", run: () => {}, local: true, runOnCi: [] }]}       | ${"number"}
+      ${[{ id: "id", run: () => {}, local: true, runOnCi: () => {} }]} | ${"number"}
+      ${[{ id: "id", run: () => {}, local: true, runOnCi: {} }]}       | ${"number"}
+      ${[{ id: "id", run: () => {}, local: true, runOnCi: null }]}     | ${"number"}
+      ${[{ id: "id", run: () => {}, local: true, runOnCi: "true" }]}   | ${"number"}
+    `(
+      "should return an issue for an invalid runOnCi property - $description",
+      ({ setup }) => {
+        const issues = [...validateCoatManifestSetup(setup)];
+
+        expect(issues).toHaveLength(1);
+        expect(issues).toEqual([
+          {
+            type: ValidationIssueType.Error,
+            message: chalk`{green setup[0].runOnCi:} must be a boolean.`,
+            propertyPath: ["setup", 0, "runOnCi"],
+            shortMessage: "must be a boolean.",
+          },
+        ]);
+      }
+    );
+
+    test("should return an issue for an unknown property - with a suggestion for runOnCi", () => {
+      const setup: CoatManifestTask[] = [
+        {
+          id: "test-id",
+          run: () => {},
+          local: true,
+          // @ts-expect-error Typo to provoke suggestion
+          runOnCI: () => true,
+        },
+      ];
+
+      const issues = [...validateCoatManifestSetup(setup)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Warning,
+          message: chalk`{green setup[0].runOnCI:} Unknown property. Did you mean {magenta runOnCi}?`,
+          propertyPath: ["setup", 0, "runOnCI"],
+        },
+      ]);
+    });
+  });
+
+  describe("global tasks", () => {
+    test("should return a warning for a runOnCi property", () => {
+      const setup: CoatManifestTask[] = [
+        {
+          id: "test-id",
+          run: () => {},
+          runOnCi: true,
+        },
+      ];
+
+      const issues = [...validateCoatManifestSetup(setup)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Warning,
+          message: chalk`{green setup[0].runOnCi:} is only used for local tasks, since global tasks are never run on CI.`,
+          propertyPath: ["setup", 0, "runOnCi"],
+        },
+      ]);
+    });
+
+    test("should return an issue for an unknown property - without a suggestion for runOnCi", () => {
+      const setup: CoatManifestTask[] = [
+        {
+          id: "test-id",
+          run: () => {},
+          // @ts-expect-error Typo to provoke suggestion (although suggestion is not desired in this case)
+          runOnCI: () => true,
+        },
+      ];
+
+      const issues = [...validateCoatManifestSetup(setup)];
+
+      expect(issues).toHaveLength(1);
+      expect(issues).toEqual([
+        {
+          type: ValidationIssueType.Warning,
+          message: chalk`{green setup[0].runOnCI:} Unknown property.`,
+          propertyPath: ["setup", 0, "runOnCI"],
+        },
+      ]);
+    });
+  });
+});

--- a/packages/cli/src/validation/coat-manifest/validate-coat-manifest-setup.ts
+++ b/packages/cli/src/validation/coat-manifest/validate-coat-manifest-setup.ts
@@ -1,0 +1,196 @@
+import chalk from "chalk";
+import { CoatManifest } from "../../types/coat-manifest";
+import { CoatManifestTask } from "../../types/coat-manifest-tasks";
+import { findPotentialPropertyMatch } from "../find-potential-property-match";
+import { formatPropertyPath } from "../format-property-path";
+import { handleUnknownProperties } from "../handle-unknown-properties";
+import { ValidationIssue, ValidationIssueType } from "../validation-issue";
+
+function* validateCoatManifestTask(
+  task: CoatManifestTask,
+  index: number
+): Generator<ValidationIssue, void, void> {
+  if (typeof task !== "object" || Array.isArray(task) || task === null) {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath(["setup", index])} must be an object.`,
+      propertyPath: ["setup", index],
+      shortMessage: "must be an object.",
+    };
+    return;
+  }
+
+  const { id, run, local, shouldRun, ...additionalProps } = task;
+
+  const additionalPropKeys = new Set(
+    Object.keys(additionalProps).filter((prop) => prop !== "runOnCi")
+  );
+
+  if (typeof id === "undefined") {
+    const potentialPropertyMatch = findPotentialPropertyMatch("id", [
+      ...additionalPropKeys,
+    ]);
+    if (potentialPropertyMatch) {
+      additionalPropKeys.delete(potentialPropertyMatch);
+      yield {
+        type: ValidationIssueType.Error,
+        message: chalk`${formatPropertyPath([
+          "setup",
+          index,
+          "id",
+        ])} must be a non-empty string. Did you misspell {magenta ${potentialPropertyMatch}}?`,
+        propertyPath: ["setup", index, potentialPropertyMatch],
+        shortMessage: chalk`did you mean to write {magenta id}?`,
+      };
+    } else {
+      yield {
+        type: ValidationIssueType.Error,
+        message: chalk`${formatPropertyPath([
+          "setup",
+          index,
+        ])} must have a {magenta id} property with a non-empty string.`,
+        propertyPath: ["setup", index],
+        shortMessage: chalk`must have a {magenta id} property with a non-empty string.`,
+      };
+    }
+  } else if (typeof id !== "string" || !id) {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath([
+        "setup",
+        index,
+        "id",
+      ])} must be a non-empty string.`,
+      propertyPath: ["setup", index, "id"],
+      shortMessage: "must be a non-empty string.",
+    };
+  }
+
+  if (typeof run === "undefined") {
+    const potentialPropertyMatch = findPotentialPropertyMatch("run", [
+      ...additionalPropKeys,
+    ]);
+    if (potentialPropertyMatch) {
+      additionalPropKeys.delete(potentialPropertyMatch);
+      yield {
+        type: ValidationIssueType.Error,
+        message: chalk`${formatPropertyPath([
+          "setup",
+          index,
+          "run",
+        ])} must be a function. Did you misspell {magenta ${potentialPropertyMatch}}?`,
+        propertyPath: ["setup", index, potentialPropertyMatch],
+        shortMessage: chalk`did you mean to write {magenta run}?`,
+      };
+    } else {
+      yield {
+        type: ValidationIssueType.Error,
+        message: chalk`${formatPropertyPath([
+          "setup",
+          index,
+        ])} must have a {magenta run} property with a function.`,
+        propertyPath: ["setup", index],
+        shortMessage: chalk`must have a {magenta run} property with a function.`,
+      };
+    }
+  } else if (typeof run !== "function") {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath([
+        "setup",
+        index,
+        "run",
+      ])} must be a function.`,
+      propertyPath: ["setup", index, "run"],
+      shortMessage: "must be a function.",
+    };
+  }
+
+  if (typeof local !== "undefined" && typeof local !== "boolean") {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath([
+        "setup",
+        index,
+        "local",
+      ])} must be a boolean.`,
+      propertyPath: ["setup", index, "local"],
+      shortMessage: "must be a boolean.",
+    };
+  }
+
+  if (task.local) {
+    if (
+      typeof task.runOnCi !== "undefined" &&
+      typeof task.runOnCi !== "boolean"
+    ) {
+      yield {
+        type: ValidationIssueType.Error,
+        message: `${formatPropertyPath([
+          "setup",
+          index,
+          "runOnCi",
+        ])} must be a boolean.`,
+        propertyPath: ["setup", index, "runOnCi"],
+        shortMessage: "must be a boolean.",
+      };
+    }
+  } else if ("runOnCi" in task) {
+    yield {
+      type: ValidationIssueType.Warning,
+      message: `${formatPropertyPath([
+        "setup",
+        index,
+        "runOnCi",
+      ])} is only used for local tasks, since global tasks are never run on CI.`,
+      propertyPath: ["setup", index, "runOnCi"],
+    };
+  }
+
+  if (typeof shouldRun !== "undefined" && typeof shouldRun !== "function") {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath([
+        "setup",
+        index,
+        "shouldRun",
+      ])} must be a function.`,
+      propertyPath: ["setup", index, "shouldRun"],
+      shortMessage: "must be a function.",
+    };
+  }
+
+  const allOptionalProps = ["local", "shouldRun"];
+  if (task.local) {
+    allOptionalProps.push("runOnCi");
+  }
+
+  yield* handleUnknownProperties({
+    allOptionalProps,
+    declaredProps: Object.keys(task),
+    unknownProps: [...additionalPropKeys],
+    propertyPrefixPath: ["setup", index],
+  });
+}
+
+export function* validateCoatManifestSetup(
+  setup: CoatManifest["setup"]
+): Generator<ValidationIssue, void, void> {
+  if (typeof setup === "undefined") {
+    return;
+  }
+
+  if (!Array.isArray(setup)) {
+    yield {
+      type: ValidationIssueType.Error,
+      message: `${formatPropertyPath(["setup"])} must be an array.`,
+      propertyPath: ["setup"],
+      shortMessage: "must be an array.",
+    };
+    return;
+  }
+
+  for (const [index, task] of setup.entries()) {
+    yield* validateCoatManifestTask(task, index);
+  }
+}

--- a/packages/cli/src/validation/find-potential-property-match.test.ts
+++ b/packages/cli/src/validation/find-potential-property-match.test.ts
@@ -1,0 +1,19 @@
+import { findPotentialPropertyMatch } from "./find-potential-property-match";
+
+describe("validation/find-potential-property-match", () => {
+  test("should return a suggestion for a potential property match", () => {
+    const property = "target";
+    const possibleProperties = ["tarrget", "testy", "test-property-2"];
+
+    expect(findPotentialPropertyMatch(property, possibleProperties)).toBe(
+      "tarrget"
+    );
+  });
+
+  test("should not return a suggestion if all properties are too far away", () => {
+    const property = "target";
+    const possibleProperties = ["testy", "test-property-2"];
+
+    expect(findPotentialPropertyMatch(property, possibleProperties)).toBe(null);
+  });
+});

--- a/packages/cli/src/validation/find-potential-property-match.ts
+++ b/packages/cli/src/validation/find-potential-property-match.ts
@@ -1,0 +1,30 @@
+import leven from "leven";
+
+/**
+ * Finds a potential property misspelling using
+ * the Levenshtein distance algorithm.
+ *
+ * @param targetProperty The unknown property that might have a spelling error
+ * @param possibleProperties Potential properties that might have been misspelled
+ * @returns The best matching property or null if none has been found
+ */
+export function findPotentialPropertyMatch(
+  targetProperty: string,
+  possibleProperties: string[]
+): string | null {
+  let bestPropertyMatch = { prop: "", distance: Infinity };
+
+  for (const possibleProp of possibleProperties) {
+    const distance = leven(targetProperty, possibleProp);
+    if (distance < bestPropertyMatch.distance) {
+      bestPropertyMatch = {
+        prop: possibleProp,
+        distance,
+      };
+    }
+  }
+
+  // We allow a maximum distance of 2 between strings to
+  // not be too lax on offering a potential property match
+  return bestPropertyMatch.distance < 3 ? bestPropertyMatch.prop : null;
+}

--- a/packages/cli/src/validation/format-property-path.test.ts
+++ b/packages/cli/src/validation/format-property-path.test.ts
@@ -1,0 +1,20 @@
+import chalk from "chalk";
+import { formatPropertyPath } from "./format-property-path";
+
+describe("validation/format-property-path", () => {
+  test("should work with an empty property path", () => {
+    expect(formatPropertyPath([])).toBe("");
+  });
+
+  test("should format a deep path with array access", () => {
+    expect(formatPropertyPath(["a", "b", 1, "c"])).toBe(
+      chalk`{green a.b[1].c:}`
+    );
+  });
+
+  test("should quote necessary properties", () => {
+    expect(
+      formatPropertyPath(["a", "@scoped/value", 1, "@another/scope"])
+    ).toBe(chalk`{green a['@scoped/value'][1]['@another/scope']:}`);
+  });
+});

--- a/packages/cli/src/validation/format-property-path.ts
+++ b/packages/cli/src/validation/format-property-path.ts
@@ -1,0 +1,36 @@
+import chalk from "chalk";
+import unquotedPropertyValidator from "unquoted-property-validator";
+
+/**
+ * Formats a property path to be displayed as a validation issue.
+ *
+ * @param propertyPath The property path that should be formatted
+ * @returns The formatted property path
+ */
+export function formatPropertyPath(propertyPath: (string | number)[]): string {
+  if (!propertyPath.length) {
+    return "";
+  }
+
+  const [head, ...tail] = propertyPath;
+
+  const tailParts = tail.reduce<string[]>((acc, prop) => {
+    // Check whether the current property must be quoted
+    // or accessed via square brackets ([])
+    const propResult = unquotedPropertyValidator(prop.toString());
+    if (propResult.needsBrackets) {
+      if (propResult.needsQuotes) {
+        acc.push(`[${propResult.quotedValue}]`);
+      } else {
+        acc.push(`[${prop}]`);
+      }
+    } else {
+      acc.push(`.${prop}`);
+    }
+    return acc;
+  }, []);
+
+  const pathResult = [head, ...tailParts].join("");
+
+  return chalk`{green ${pathResult}:}`;
+}

--- a/packages/cli/src/validation/handle-unknown-properties.test.ts
+++ b/packages/cli/src/validation/handle-unknown-properties.test.ts
@@ -1,0 +1,91 @@
+import chalk from "chalk";
+import { handleUnknownProperties } from "./handle-unknown-properties";
+import { ValidationIssueType } from "./validation-issue";
+
+describe("validation/handle-unknown-properties", () => {
+  test("should return no issues without any unknown properties", () => {
+    const allPossibleProps: string[] = [];
+    const unknownProps: string[] = [];
+    const declaredProps: string[] = [];
+
+    const issues = [
+      ...handleUnknownProperties({
+        allOptionalProps: allPossibleProps,
+        unknownProps,
+        declaredProps,
+      }),
+    ];
+
+    expect(issues).toHaveLength(0);
+  });
+
+  test("should return a suggestion if a property is slightly mis-spelled", () => {
+    const allPossibleProps: string[] = ["possible", "different", "third"];
+    const unknownProps: string[] = ["posssible"];
+    const declaredProps: string[] = [];
+
+    const issues = [
+      ...handleUnknownProperties({
+        allOptionalProps: allPossibleProps,
+        unknownProps,
+        declaredProps,
+      }),
+    ];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green posssible:} Unknown property. Did you mean {magenta possible}?`,
+        propertyPath: ["posssible"],
+      },
+    ]);
+  });
+
+  test("should not return a suggestion if a property has no close match", () => {
+    const allPossibleProps: string[] = ["possible", "different", "third"];
+    const unknownProps: string[] = ["somethingElse"];
+    const declaredProps: string[] = [];
+
+    const issues = [
+      ...handleUnknownProperties({
+        allOptionalProps: allPossibleProps,
+        unknownProps,
+        declaredProps,
+      }),
+    ];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green somethingElse:} Unknown property.`,
+        propertyPath: ["somethingElse"],
+      },
+    ]);
+  });
+
+  test("should add property prefix to property path", () => {
+    const allPossibleProps: string[] = ["possible", "different", "third"];
+    const unknownProps: string[] = ["posssible"];
+    const declaredProps: string[] = [];
+
+    const issues = [
+      ...handleUnknownProperties({
+        allOptionalProps: allPossibleProps,
+        unknownProps,
+        declaredProps,
+        propertyPrefixPath: ["prefix", 0, "are"],
+      }),
+    ];
+
+    expect(issues).toHaveLength(1);
+    expect(issues).toEqual([
+      {
+        type: ValidationIssueType.Warning,
+        message: chalk`{green prefix[0].are.posssible:} Unknown property. Did you mean {magenta possible}?`,
+        propertyPath: ["prefix", 0, "are", "posssible"],
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/validation/handle-unknown-properties.ts
+++ b/packages/cli/src/validation/handle-unknown-properties.ts
@@ -1,0 +1,54 @@
+import chalk from "chalk";
+import { findPotentialPropertyMatch } from "./find-potential-property-match";
+import { formatPropertyPath } from "./format-property-path";
+import { ValidationIssue, ValidationIssueType } from "./validation-issue";
+
+interface HandleUnknownPropertiesInput {
+  unknownProps: string[];
+  declaredProps: string[];
+  allOptionalProps: string[];
+  propertyPrefixPath?: (string | number)[];
+}
+
+/**
+ * Validation helper to generate issues for unknown properties in an object.
+ *
+ * @param input.allOptionalProps Potential optional properties of an object,
+ * required properties should be handled directly in the specific validation methods.
+ * @param input.unknownProps Additional props that have been declared and don't correspond
+ * to the known schema.
+ * @param input.declaredProps All properties that are already declared on the object,
+ * to exclude suggestions for already set properties.
+ * @param input.propertyPrefixPath The path to the current property, to prefix the
+ * formatted result if necessary.
+ */
+export function* handleUnknownProperties({
+  allOptionalProps,
+  unknownProps,
+  declaredProps,
+  propertyPrefixPath = [],
+}: HandleUnknownPropertiesInput): Generator<ValidationIssue, void, void> {
+  // Remove already declared properties from potential property matches
+  const possibleProps = allOptionalProps.filter(
+    (prop) => !declaredProps.includes(prop)
+  );
+
+  for (const prop of unknownProps) {
+    const bestPropertyMatch = findPotentialPropertyMatch(prop, possibleProps);
+
+    const propertyPath = [...propertyPrefixPath, prop];
+    const messageParts = [
+      `${formatPropertyPath(propertyPath)} Unknown property.`,
+    ];
+
+    if (bestPropertyMatch) {
+      messageParts.push(chalk` Did you mean {magenta ${bestPropertyMatch}}?`);
+    }
+
+    yield {
+      type: ValidationIssueType.Warning,
+      message: messageParts.join(""),
+      propertyPath,
+    };
+  }
+}

--- a/packages/cli/src/validation/validation-issue.ts
+++ b/packages/cli/src/validation/validation-issue.ts
@@ -1,0 +1,32 @@
+export enum ValidationIssueType {
+  Warning = "WARNING",
+  Error = "ERROR",
+}
+
+interface ValidationIssueBase {
+  type: ValidationIssueType;
+  /**
+   * The validation issue message that will be displayed to the user
+   */
+  message: string;
+  /**
+   * The path to the property, to display a code frame surrounding the
+   * validation issue. This property must be defined on the object.
+   */
+  propertyPath: (string | number)[];
+}
+
+export interface ValidationIssueError extends ValidationIssueBase {
+  type: ValidationIssueType.Error;
+  /**
+   * A short validation error message that will be displayed inline
+   * with the source code if possible
+   */
+  shortMessage: string;
+}
+
+export interface ValidationIssueWarning extends ValidationIssueBase {
+  type: ValidationIssueType.Warning;
+}
+
+export type ValidationIssue = ValidationIssueError | ValidationIssueWarning;

--- a/packages/cli/test/sync/flows.test.ts
+++ b/packages/cli/test/sync/flows.test.ts
@@ -56,7 +56,6 @@ describe("sync/flows", () => {
         CREATED  global.json
         CREATED  local-once.json
         CREATED  local.json
-        UPDATED  package.json
       "
     `);
 

--- a/packages/cli/test/utils/run-cli-test.ts
+++ b/packages/cli/test/utils/run-cli-test.ts
@@ -85,11 +85,11 @@ export async function prepareCliTest(
   const filePromises = [
     fs.writeFile(
       path.join(tmpDir, PACKAGE_JSON_FILENAME),
-      JSON.stringify(packageJson)
+      JSON.stringify(packageJson, null, 2)
     ),
     fs.writeFile(
       path.join(tmpDir, COAT_MANIFEST_FILENAME),
-      JSON.stringify(coatManifest)
+      JSON.stringify(coatManifest, null, 2)
     ),
   ];
 

--- a/packages/cli/test/utils/test-packages/local-template-async-fn-error-1/index.js
+++ b/packages/cli/test/utils/test-packages/local-template-async-fn-error-1/index.js
@@ -1,0 +1,5 @@
+module.exports = async function () {
+  return {
+    name: "local-template-async-fn-error-1",
+  };
+};


### PR DESCRIPTION
Validates the coat manifest file (coat.json) and extended coat templates.

If there are any errors during validation, the coat cli will throw.

Fixes #18 [CLI] Validate coat manifest properties