### PR TITLE
feat: 🔼 Update TypeScript to 4.4

### DIFF
--- a/coat.code-workspace
+++ b/coat.code-workspace
@@ -20,7 +20,8 @@
     "task.quickOpen.history": 0,
     "files.exclude": {
       "packages": true
-    }
+    },
+    "typescript.tsdk": "✨ coat/node_modules/typescript/lib"
   },
   "extensions": {
     "recommendations": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "prompts": "2.4.1",
         "rimraf": "3.0.2",
         "ts-node": "10.2.1",
-        "typescript": "4.3.5"
+        "typescript": "4.4.2"
       }
     },
     "node_modules/@babel/cli": {
@@ -11019,6 +11019,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/ts-json-schema-generator/node_modules/typescript": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
@@ -11148,9 +11161,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11922,7 +11935,7 @@
         "strip-ansi": "6.0.0",
         "ts-json-schema-generator": "0.95.0",
         "ts-node": "10.2.1",
-        "typescript": "4.3.5",
+        "typescript": "4.4.2",
         "which": "2.0.2"
       },
       "engines": {
@@ -11963,7 +11976,7 @@
         "prettier": "2.3.2",
         "rimraf": "3.0.2",
         "tmp": "0.2.1",
-        "typescript": "4.3.5"
+        "typescript": "4.4.2"
       },
       "peerDependencies": {
         "@coat/cli": "^0.0.23"
@@ -13244,7 +13257,7 @@
         "ts-json-schema-generator": "0.95.0",
         "ts-node": "10.2.1",
         "type-fest": "1.4.0",
-        "typescript": "4.3.5",
+        "typescript": "4.4.2",
         "unquoted-property-validator": "1.1.0",
         "which": "2.0.2",
         "wrap-ansi": "7.0.0"
@@ -13278,7 +13291,7 @@
         "prettier": "2.3.2",
         "rimraf": "3.0.2",
         "tmp": "0.2.1",
-        "typescript": "4.3.5"
+        "typescript": "4.4.2"
       }
     },
     "@commitlint/cli": {
@@ -20420,6 +20433,14 @@
         "json-stable-stringify": "^1.0.1",
         "json5": "^2.2.0",
         "typescript": "~4.3.4"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+          "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+          "dev": true
+        }
       }
     },
     "ts-node": {
@@ -20502,9 +20523,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prompts": "2.4.1",
     "rimraf": "3.0.2",
     "ts-node": "10.2.1",
-    "typescript": "4.3.5"
+    "typescript": "4.4.2"
   },
   "homepage": "https://github.com/coat-dev/coat#readme",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
     "strip-ansi": "6.0.0",
     "ts-json-schema-generator": "0.95.0",
     "ts-node": "10.2.1",
-    "typescript": "4.3.5",
+    "typescript": "4.4.2",
     "which": "2.0.2"
   },
   "engines": {

--- a/packages/cli/src/bin/cli.test.ts
+++ b/packages/cli/src/bin/cli.test.ts
@@ -1,3 +1,4 @@
+import { ExecaError } from "execa";
 import { version } from "../../package.json";
 import { createProgram } from "./cli";
 import { create } from "../create";
@@ -45,7 +46,7 @@ describe("coat cli", () => {
     } catch (error) {
       expect(stdoutMock).toHaveBeenCalledTimes(1);
       expect(stdoutMock).toHaveBeenCalledWith(`${version}\n`);
-      expect(error.exitCode).toBe(0);
+      expect((error as ExecaError).exitCode).toBe(0);
     }
   });
 

--- a/packages/cli/src/bin/cli.ts
+++ b/packages/cli/src/bin/cli.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { ExecaError } from "execa";
 import { COAT_CLI_VERSION } from "../constants";
 import { create } from "../create";
 import { run } from "../run";
@@ -67,8 +68,11 @@ export function createProgram(): Command {
         });
       } catch (error) {
         // Exit immediately with the exitCode if a script has thrown an error
-        if (error.exitCode) {
-          process.exit(error.exitCode);
+        if (typeof (error as ExecaError).exitCode !== "undefined") {
+          const execaError = error as ExecaError;
+          if (execaError.exitCode !== 0) {
+            process.exit(execaError.exitCode);
+          }
         }
         // Otherwise rethrow the error directly
         throw error;
@@ -91,8 +95,11 @@ export function createProgram(): Command {
     } catch (error) {
       // If the error has an exitCode property, it has
       // been thrown from a script that has been run.
-      if (error.exitCode) {
-        process.exit(error.exitCode);
+      if (typeof (error as ExecaError).exitCode !== "undefined") {
+        const execaError = error as ExecaError;
+        if (execaError.exitCode !== 0) {
+          process.exit(execaError.exitCode);
+        }
       } else {
         // If there is no exitCode, the error has to be in an earlier
         // part of the run function, e.g. because no package.json file exists

--- a/packages/cli/src/create/index.ts
+++ b/packages/cli/src/create/index.ts
@@ -97,7 +97,7 @@ export async function create({
     // If this line is reached the coat manifest file already exists
     coatManifestExists = true;
   } catch (error) {
-    if (error.code !== "ENOENT") {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       // If the error is not due to a missing file, but e.g. due
       // to missing permissions it should be thrown to the user
       throw error;
@@ -122,7 +122,7 @@ export async function create({
     );
     previousPackageJson = JSON.parse(previousPackageJsonRaw);
   } catch (error) {
-    if (error.code !== "ENOENT") {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       // If the error is not due to a missing file, but e.g. due
       // to missing permissions it should be thrown to the user
       throw error;

--- a/packages/cli/src/lockfiles/get-coat-lockfiles.ts
+++ b/packages/cli/src/lockfiles/get-coat-lockfiles.ts
@@ -50,7 +50,7 @@ export async function getCoatGlobalLockfile(
     lockfile = yaml.load(lockfileRaw) as CoatGlobalLockfile;
   } catch (error) {
     // Throw if error is anything other than "not found"
-    if (error.code !== "ENOENT") {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error;
     }
   }
@@ -91,7 +91,7 @@ export async function getCoatLocalLockfile(
     lockfile = yaml.load(lockfileRaw) as CoatGlobalLockfileStrict;
   } catch (error) {
     // Throw if error is anything other than "not found"
-    if (error.code !== "ENOENT") {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error;
     }
   }

--- a/packages/cli/src/sync/get-current-files.ts
+++ b/packages/cli/src/sync/get-current-files.ts
@@ -19,7 +19,7 @@ export async function getCurrentFiles(
         // to match them back together later in an object
         return [filePath, content];
       } catch (error) {
-        if (error.code === "ENOENT") {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
           // File doesn't exist, return the key with an undefined content
           return [filePath];
         }

--- a/packages/cli/src/sync/merge-files.test.ts
+++ b/packages/cli/src/sync/merge-files.test.ts
@@ -289,7 +289,7 @@ describe("sync/merge-files", () => {
     try {
       await mergeFiles(files, testContext);
     } catch (error) {
-      expect(error.message).toMatchInlineSnapshot(
+      expect((error as Error).message).toMatchInlineSnapshot(
         `"Cannot merge unknown file type: unknown"`
       );
     }
@@ -317,7 +317,9 @@ describe("sync/merge-files", () => {
     try {
       await mergeFiles(files, testContext);
     } catch (error) {
-      expect(error.message).toMatchInlineSnapshot(`"Something went wrong"`);
+      expect((error as Error).message).toMatchInlineSnapshot(
+        `"Something went wrong"`
+      );
     }
   });
 
@@ -503,7 +505,9 @@ describe("sync/merge-files", () => {
       try {
         await mergeFiles(files, testContext);
       } catch (error) {
-        expect(error.message).toMatchInlineSnapshot(`"Parsing issue"`);
+        expect((error as Error).message).toMatchInlineSnapshot(
+          `"Parsing issue"`
+        );
       }
     });
   });

--- a/packages/cli/src/sync/merge-files.ts
+++ b/packages/cli/src/sync/merge-files.ts
@@ -122,7 +122,7 @@ export async function mergeFiles(
         await fs.stat(customizationFilePath);
         // File exists
       } catch (error) {
-        if (error.code === "ENOENT") {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
           // File does not exist -> no customization
           return [filePath, file];
         }

--- a/packages/cli/src/util/delete-file.ts
+++ b/packages/cli/src/util/delete-file.ts
@@ -18,7 +18,7 @@ export async function deleteFile(filePath: string): Promise<void> {
     // test in test/sync/delete-unmanaged-files.test.ts:
     // "should throw errors if unmanaged files cannot be accessed"
     /* istanbul ignore if */
-    if (error.code !== "ENOENT") {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       // If there is an error other than the file not
       // being available (anymore) it is thrown
       throw error;

--- a/packages/cli/src/util/get-package-json.ts
+++ b/packages/cli/src/util/get-package-json.ts
@@ -18,7 +18,7 @@ export async function getPackageJson(
     );
     return JSON.parse(packageJsonRaw);
   } catch (error) {
-    if (error.code !== "ENOENT") {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error;
     }
     // If the file is not available, packageJson will

--- a/packages/cli/test/create/errors.test.ts
+++ b/packages/cli/test/create/errors.test.ts
@@ -3,6 +3,7 @@ import fs from "fs-extra";
 import path from "path";
 import { getTmpDir } from "../utils/get-tmp-dir";
 import { COAT_MANIFEST_FILENAME } from "../../src/constants";
+import { ExecaError } from "execa";
 
 describe("coat create - errors", () => {
   test("should throw error if no template is specified", async () => {
@@ -14,7 +15,7 @@ describe("coat create - errors", () => {
       // task throws an error
       throw new Error("Error! Task should have thrown an error");
     } catch (error) {
-      expect(error.stderr).toMatchInlineSnapshot(
+      expect((error as ExecaError).stderr).toMatchInlineSnapshot(
         `"error: missing required argument 'template'"`
       );
     }
@@ -33,7 +34,7 @@ describe("coat create - errors", () => {
       // task throws an error
       throw new Error("Error! Task should have thrown an error");
     } catch (error) {
-      expect(error.stderr).toEqual(
+      expect((error as ExecaError).stderr).toEqual(
         expect.stringContaining(
           "npm ERR! 404 Not Found - GET https://registry.npmjs.org/@coat%2fnon-existent-package - Not found"
         )
@@ -57,7 +58,7 @@ describe("coat create - errors", () => {
       // task throws an error
       throw new Error("Error! Task should have thrown an error");
     } catch (error) {
-      expect(error.stderr).toContain(
+      expect((error as ExecaError).stderr).toContain(
         "A coat manifest file already exists in the target directory.\n\nPlease install the template manually via npm and add the name of the template to the existing coat manifest file."
       );
 

--- a/packages/cli/test/run/general.test.ts
+++ b/packages/cli/test/run/general.test.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "fs";
 import path from "path";
+import { ExecaError } from "execa";
 import { PACKAGE_JSON_FILENAME } from "../../src/constants";
 import { getTmpDir } from "../utils/get-tmp-dir";
 import { runCli } from "../utils/run-cli";
@@ -109,7 +110,7 @@ describe("coat run - general", () => {
       await runTask;
       throw new Error("should not be reached");
     } catch (error) {
-      expect(error.exitCode).toBe(5);
+      expect((error as ExecaError).exitCode).toBe(5);
     }
   });
 
@@ -138,8 +139,8 @@ describe("coat run - general", () => {
       await runTask;
       throw new Error("should not be reached");
     } catch (error) {
-      expect(error.stdout).not.toContain("Done");
-      expect(error.exitCode).toBe(5);
+      expect((error as ExecaError).stdout).not.toContain("Done");
+      expect((error as ExecaError).exitCode).toBe(5);
     }
   });
 });

--- a/packages/cli/test/run/unknown-commands.test.ts
+++ b/packages/cli/test/run/unknown-commands.test.ts
@@ -1,3 +1,4 @@
+import { ExecaError } from "execa";
 import { runCli } from "../utils/run-cli";
 import { runSyncTest } from "../utils/run-cli-test";
 
@@ -70,7 +71,7 @@ describe("run/unknown-commands", () => {
       await runTask;
       throw new Error("Line should not be reached");
     } catch (error) {
-      expect(error.exitCode).toBe(5);
+      expect((error as ExecaError).exitCode).toBe(5);
     }
   });
 
@@ -99,8 +100,8 @@ describe("run/unknown-commands", () => {
       await runTask;
       throw new Error("Line should not be reached");
     } catch (error) {
-      expect(error.stdout).not.toContain("Done");
-      expect(error.exitCode).toBe(5);
+      expect((error as ExecaError).stdout).not.toContain("Done");
+      expect((error as ExecaError).exitCode).toBe(5);
     }
   });
 
@@ -108,8 +109,8 @@ describe("run/unknown-commands", () => {
     try {
       await runCli(["test-script"]).task;
     } catch (error) {
-      expect(error.exitCode).toBe(1);
-      expect(error.stderr).toMatchInlineSnapshot(
+      expect((error as ExecaError).exitCode).toBe(1);
+      expect((error as ExecaError).stderr).toMatchInlineSnapshot(
         `"error: unknown script or command 'test-script'. See 'coat --help'"`
       );
     }

--- a/packages/cli/test/sync/check.test.ts
+++ b/packages/cli/test/sync/check.test.ts
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import path from "path";
 import stripAnsi from "strip-ansi";
 import yaml from "js-yaml";
+import { ExecaError } from "execa";
 import {
   COAT_GLOBAL_LOCKFILE_PATH,
   COAT_GLOBAL_LOCKFILE_VERSION,
@@ -136,8 +137,8 @@ describe("coat sync - --check option", () => {
       await checkTask;
       throw new Error("checkTask should fail");
     } catch (error) {
-      expect(error.exitCode).toBe(1);
-      expect(stripAnsi(error.stderr)).toMatchInlineSnapshot(`
+      expect((error as ExecaError).exitCode).toBe(1);
+      expect(stripAnsi((error as ExecaError).stderr)).toMatchInlineSnapshot(`
         "
         The coat project is not in sync.
         There are global tasks pending that need to be run to setup this coat project.
@@ -179,8 +180,8 @@ describe("coat sync - --check option", () => {
       await checkTask;
       throw new Error("checkTask should fail");
     } catch (error) {
-      expect(error.exitCode).toBe(1);
-      expect(stripAnsi(error.stderr)).toMatchInlineSnapshot(`
+      expect((error as ExecaError).exitCode).toBe(1);
+      expect(stripAnsi((error as ExecaError).stderr)).toMatchInlineSnapshot(`
         "
         The coat project is not in sync.
         The global lockfile (coat.lock) needs to be updated.
@@ -223,8 +224,8 @@ describe("coat sync - --check option", () => {
       await checkTask;
       throw new Error("checkTask should fail");
     } catch (error) {
-      expect(error.exitCode).toBe(1);
-      expect(stripAnsi(error.stderr)).toMatchInlineSnapshot(`
+      expect((error as ExecaError).exitCode).toBe(1);
+      expect(stripAnsi((error as ExecaError).stderr)).toMatchInlineSnapshot(`
         "
         The coat project is not in sync.
         The global lockfile (coat.lock) needs to be updated.
@@ -294,8 +295,8 @@ describe("coat sync - --check option", () => {
       await checkTask;
       throw new Error("checkTask should fail");
     } catch (error) {
-      expect(error.exitCode).toBe(1);
-      expect(stripAnsi(error.stderr)).toMatchInlineSnapshot(`
+      expect((error as ExecaError).exitCode).toBe(1);
+      expect(stripAnsi((error as ExecaError).stderr)).toMatchInlineSnapshot(`
         "
         The coat project is not in sync.
         There are pending file updates:

--- a/packages/cli/test/sync/dependencies.test.ts
+++ b/packages/cli/test/sync/dependencies.test.ts
@@ -151,7 +151,9 @@ describe("coat sync - dependencies", () => {
           );
         } catch (error) {
           expect(
-            error.message.includes("ENOENT: no such file or directory,")
+            (error as Error).message.includes(
+              "ENOENT: no such file or directory,"
+            )
           ).toBe(true);
         }
       }
@@ -266,9 +268,9 @@ describe("coat sync - dependencies", () => {
       await fs.stat(path.join(cwd, "node_modules", "local-dependency-before"));
       throw new Error("Error! Old dependency directory should no longer exist");
     } catch (error) {
-      expect(error.message.includes("ENOENT: no such file or directory,")).toBe(
-        true
-      );
+      expect(
+        (error as Error).message.includes("ENOENT: no such file or directory,")
+      ).toBe(true);
     }
     const afterStatResult = await fs.stat(
       path.join(cwd, "node_modules", "local-dependency-after")

--- a/packages/cli/test/sync/errors.test.ts
+++ b/packages/cli/test/sync/errors.test.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs";
 import path from "path";
 import stripAnsi from "strip-ansi";
+import { ExecaError } from "execa";
 import { prepareCliTest, runSyncTest } from "../utils/run-cli-test";
 import {
   COAT_MANIFEST_FILENAME,
@@ -22,9 +23,11 @@ describe("coat sync - errors", () => {
       throw new Error("This error should not be reached. Task should throw");
     } catch (error) {
       expect(
-        error.stderr.includes("Error: ENOENT: no such file or directory,")
+        (error as ExecaError).stderr.includes(
+          "Error: ENOENT: no such file or directory,"
+        )
       ).toBe(true);
-      expect(error.stderr.includes("coat.json")).toBe(true);
+      expect((error as ExecaError).stderr.includes("coat.json")).toBe(true);
     }
   });
 
@@ -41,9 +44,11 @@ describe("coat sync - errors", () => {
       await task;
       throw new Error("This error should not be reached. Task should throw");
     } catch (error) {
-      expect(error.stderr.includes("Cannot find module 'test-template'")).toBe(
-        true
-      );
+      expect(
+        (error as ExecaError).stderr.includes(
+          "Cannot find module 'test-template'"
+        )
+      ).toBe(true);
     }
   });
 
@@ -70,7 +75,10 @@ describe("coat sync - errors", () => {
       //
       // Only use first 13 lines to exclude stack trace with platform specific paths
       // in temporary directories
-      const errorMessage = error.stderr.split("\n").slice(0, 13).join("\n");
+      const errorMessage = (error as ExecaError).stderr
+        .split("\n")
+        .slice(0, 13)
+        .join("\n");
       expect(stripAnsi(errorMessage)).toMatchInlineSnapshot(`
         "The coat manifest file (coat.json) has the following issue:
 
@@ -113,7 +121,7 @@ describe("coat sync - errors", () => {
       throw new Error("This error should not be reached. Task should throw");
     } catch (error) {
       // Error is already thrown at validation time
-      const errorMessage = stripAnsi(error.stderr);
+      const errorMessage = stripAnsi((error as ExecaError).stderr);
       expect(errorMessage).toContain(
         `The extended template "${localTemplateWithAsyncFunction}" has the following issue:`
       );
@@ -135,10 +143,12 @@ describe("coat sync - errors", () => {
         await task;
         throw new Error("This error should not be reached. Task should throw");
       } catch (error) {
-        expect(error.stderr.includes("Error: EACCES: permission denied,")).toBe(
-          true
-        );
-        expect(error.stderr.includes("coat.json")).toBe(true);
+        expect(
+          (error as ExecaError).stderr.includes(
+            "Error: EACCES: permission denied,"
+          )
+        ).toBe(true);
+        expect((error as ExecaError).stderr.includes("coat.json")).toBe(true);
       }
     }
   );
@@ -155,10 +165,14 @@ describe("coat sync - errors", () => {
         await task;
         throw new Error("This error should not be reached. Task should throw");
       } catch (error) {
-        expect(error.stderr.includes("Error: EACCES: permission denied,")).toBe(
+        expect(
+          (error as ExecaError).stderr.includes(
+            "Error: EACCES: permission denied,"
+          )
+        ).toBe(true);
+        expect((error as ExecaError).stderr.includes("package.json")).toBe(
           true
         );
-        expect(error.stderr.includes("package.json")).toBe(true);
       }
     }
   );
@@ -191,11 +205,15 @@ describe("coat sync - errors", () => {
         await task;
         throw new Error("This error should not be reached. Task should throw");
       } catch (error) {
-        expect(error.stderr.includes("Error: EACCES: permission denied,")).toBe(
-          true
-        );
         expect(
-          error.stderr.includes(path.join("some-folder", "file.json"))
+          (error as ExecaError).stderr.includes(
+            "Error: EACCES: permission denied,"
+          )
+        ).toBe(true);
+        expect(
+          (error as ExecaError).stderr.includes(
+            path.join("some-folder", "file.json")
+          )
         ).toBe(true);
       }
     }

--- a/packages/cli/test/sync/general.test.ts
+++ b/packages/cli/test/sync/general.test.ts
@@ -66,7 +66,7 @@ describe("coat sync - general", () => {
         "Code should not be reached, stat call should throw error"
       );
     } catch (error) {
-      expect(error.message).toContain(
+      expect((error as Error).message).toContain(
         "ENOENT: no such file or directory, stat"
       );
     }

--- a/packages/template-ts-package/package.json
+++ b/packages/template-ts-package/package.json
@@ -21,7 +21,7 @@
     "prettier": "2.3.2",
     "rimraf": "3.0.2",
     "tmp": "0.2.1",
-    "typescript": "4.3.5"
+    "typescript": "4.4.2"
   },
   "files": [
     "build/",

--- a/packages/template-ts-package/src/__snapshots__/index.test.ts.snap
+++ b/packages/template-ts-package/src/__snapshots__/index.test.ts.snap
@@ -277,7 +277,7 @@ exports[`@coat/template-ts-package template verification - babel compiler 8`] = 
     \\"jest\\": \\"^27.0.1\\",
     \\"prettier\\": \\"^2.2.0\\",
     \\"rimraf\\": \\"^3.0.2\\",
-    \\"typescript\\": \\"~4.3.2\\"
+    \\"typescript\\": \\"~4.4.2\\"
   },
   \\"files\\": [
     \\"build/\\"
@@ -607,7 +607,7 @@ exports[`@coat/template-ts-package template verification - default config 7`] = 
     \\"prettier\\": \\"^2.2.0\\",
     \\"rimraf\\": \\"^3.0.2\\",
     \\"ts-jest\\": \\"^27.0.4\\",
-    \\"typescript\\": \\"~4.3.2\\"
+    \\"typescript\\": \\"~4.4.2\\"
   },
   \\"files\\": [
     \\"build/\\"
@@ -932,7 +932,7 @@ exports[`@coat/template-ts-package template verification - typescript compiler 7
     \\"prettier\\": \\"^2.2.0\\",
     \\"rimraf\\": \\"^3.0.2\\",
     \\"ts-jest\\": \\"^27.0.4\\",
-    \\"typescript\\": \\"~4.3.2\\"
+    \\"typescript\\": \\"~4.4.2\\"
   },
   \\"files\\": [
     \\"build/\\"

--- a/packages/template-ts-package/src/index.ts
+++ b/packages/template-ts-package/src/index.ts
@@ -115,7 +115,7 @@ const createTemplate: CoatTemplate = ({ coatContext, config: userConfig }) => {
     "@types/jest": "^27.0.1",
 
     prettier: "^2.2.0",
-    typescript: "~4.3.2",
+    typescript: "~4.4.2",
     rimraf: "^3.0.2",
   };
 


### PR DESCRIPTION
Updates all TypeScript dependencies to 4.4, including the generated version of the `template-ts-package`.

Errors are no longer typed as any, which required to cast errors to the specific type in catch statements. More information: https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/